### PR TITLE
Feature/support folder and file adapter

### DIFF
--- a/pkg/adapters/source/file.go
+++ b/pkg/adapters/source/file.go
@@ -45,17 +45,29 @@ func NewFileAdapter(config AdapterConfig) (*FileAdapter, error) {
 
 // GetSBOMs implements InputAdapter
 func (a *FileAdapter) GetSBOMs(ctx context.Context) ([]string, error) {
-	// TODO: Implement Interlynk API integration
-	return nil, fmt.Errorf("not implemented")
+	if !a.isDir {
+		// For single file, just read and return it
+		_, err := os.ReadFile(a.path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read file: %w", err)
+		}
+
+		return []string{a.path}, nil
+	}
+
+	return nil, fmt.Errorf("FileAdapter cannot process directories, use FolderAdapter instead")
+}
+
+func (a *FileAdapter) readSBOMFile(path string) (string, error) {
+	_, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file: %w", err)
+	}
+	return path, nil
 }
 
 func isSBOMFile(name string) bool {
 	// TODO: Implement better SBOM file detection
 	ext := filepath.Ext(name)
 	return ext == ".json" || ext == ".xml" || ext == ".spdx" || ext == ".cdx"
-}
-
-func detectSBOMFormat(content []byte) SBOMFormat {
-	// TODO: Implement format detection based on content
-	return FormatUnknown
 }

--- a/pkg/utils/detect.go
+++ b/pkg/utils/detect.go
@@ -28,7 +28,6 @@ func DetectSourceType(urlStr string) (source.InputSource, error) {
 	// Check if it's a valid URL
 	u, err := url.Parse(urlStr)
 	if err != nil || u.Scheme == "" {
-		// If not a URL, check if it's a local file or directory
 		return DetectLocalSourceType(urlStr), nil
 	}
 
@@ -39,7 +38,7 @@ func DetectSourceType(urlStr string) (source.InputSource, error) {
 	case strings.Contains(host, "github.com"):
 		return source.SourceGithub, nil
 
-	case strings.Contains(host, "interlynk.io") || strings.Contains(urlStr, "lynapi"):
+	case strings.Contains(host, "interlynk.io") || strings.Contains(urlStr, "lynkapi"):
 		return source.SourceInterlynk, nil
 
 	case strings.Contains(host, "dependencytrack.com"):

--- a/pkg/utils/validate.go
+++ b/pkg/utils/validate.go
@@ -1,0 +1,124 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// validateAddressString validates if the provided string is either a valid URL or file path.
+// Returns an error if the string is neither a valid URL nor a valid file path.
+func validateAddressString(addr string) error {
+	// First try to parse as URL
+	if u, err := url.Parse(addr); err == nil && u.Scheme != "" {
+		// Valid URL with scheme
+		return validateURL(u)
+	}
+
+	// If not a URL, validate as file path
+	return validatePath(addr)
+}
+
+// validateURL performs additional validation on URLs
+func validateURL(u *url.URL) error {
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+		if u.Host == "" {
+			return fmt.Errorf("missing host in URL: %s", u.String())
+		}
+		return nil
+	case "file":
+		return validatePath(u.Path)
+	case "s3":
+		if u.Host == "" {
+			return fmt.Errorf("missing bucket name in S3 URL: %s", u.String())
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported URL scheme: %s", u.Scheme)
+	}
+}
+
+// validatePath checks if a path is valid and accessible
+func validatePath(path string) error {
+	// Clean the path to handle . and .. segments
+	path = filepath.Clean(path)
+
+	// Check if path is absolute and exists
+	if filepath.IsAbs(path) {
+		return validateExistingPath(path)
+	}
+
+	// For relative paths, convert to absolute
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("invalid relative path: %w", err)
+	}
+	return validateExistingPath(absPath)
+}
+
+// validateExistingPath checks if a path exists and is accessible
+func validateExistingPath(path string) error {
+	// Check if path exists
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Special case: if this is a target path for writing,
+			// check if the parent directory exists and is writable
+			parentDir := filepath.Dir(path)
+			parentInfo, parentErr := os.Stat(parentDir)
+			if parentErr == nil && parentInfo.IsDir() {
+				return nil // Parent directory exists, which is good enough for a target path
+			}
+			return fmt.Errorf("path does not exist: %s", path)
+		}
+		if os.IsPermission(err) {
+			return fmt.Errorf("permission denied accessing path: %s", path)
+		}
+		return fmt.Errorf("error accessing path: %w", err)
+	}
+
+	// Check if it's a directory and accessible
+	if info.IsDir() {
+		// Try to read directory to verify permissions
+		f, err := os.Open(path)
+		if err != nil {
+			return fmt.Errorf("cannot access directory: %w", err)
+		}
+		f.Close()
+		return nil
+	}
+
+	return nil
+}
+
+// ValidateURLs validates both source and target address strings
+func ValidateURLs(fromURL, toURL string) error {
+	// Validate source
+	if err := validateAddressString(fromURL); err != nil {
+		return fmt.Errorf("invalid source address: %w", err)
+	}
+
+	// Validate target
+	if err := validateAddressString(toURL); err != nil {
+		return fmt.Errorf("invalid target address: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR add following changes:
- Implements FileAdapter and FolderAdapter
- Convert content and extension of a file, only if it's extension has `.spdx`. As interlynk platform doesn't except `.spdx` sbom files.
- validates both URLs and path correctly.