### PR TITLE
Feat/GitHub version wise release

### DIFF
--- a/pkg/adapters/dest/interlynk.go
+++ b/pkg/adapters/dest/interlynk.go
@@ -73,9 +73,9 @@ func (a *InterlynkAdapter) UploadSBOMs(ctx context.Context, sboms []string) erro
 	// Log results
 	for _, result := range results {
 		if result.Error != nil {
-			logger.LogInfo(ctx, "Failed to upload SBOMs", "response", result.Error)
+			logger.LogDebug(ctx, "Failed to upload SBOMs", "response", result.Error)
 		} else {
-			logger.LogInfo(ctx, "SBOM uploaded successfully", "file", result.Path)
+			logger.LogDebug(ctx, "SBOM uploaded successfully", "file", result.Path)
 		}
 	}
 	return nil

--- a/pkg/adapters/source/github.go
+++ b/pkg/adapters/source/github.go
@@ -65,10 +65,10 @@ func NewGitHubAdapter(config mvtypes.Config) *GitHubAdapter {
 func (a *GitHubAdapter) GetSBOMs(ctx context.Context) ([]string, error) {
 	switch a.method {
 	case MethodReleases:
-		logger.LogInfo(ctx, "Get SBOMs from Release Page", "method", MethodReleases)
+		logger.LogDebug(ctx, "Get SBOMs from Release Page", "method", MethodReleases)
 		return a.getSBOMsFromReleases(ctx)
 	case MethodGenerate:
-		logger.LogInfo(ctx, "Get SBOMs from tools", "method", MethodGenerate)
+		logger.LogDebug(ctx, "Get SBOMs from tools", "method", MethodGenerate)
 		return a.generateSBOMs(ctx)
 	default:
 		return nil, fmt.Errorf("unsupported GitHub method: %v", a.method)

--- a/pkg/mvtypes/types.go
+++ b/pkg/mvtypes/types.go
@@ -16,8 +16,18 @@
 package mvtypes
 
 type Config struct {
-	SourceType         string
-	DestinationType    string
-	SourceConfigs      map[string]interface{}
+	// source adapter type
+	SourceType string
+
+	// destination adapter type
+	DestinationType string
+
+	// source adapter related all parameters
+	SourceConfigs map[string]interface{}
+
+	// destination adapter related all parameters
 	DestinationConfigs map[string]interface{}
+
+	// dry run mode
+	DryRun bool
 }

--- a/pkg/sbom/format.go
+++ b/pkg/sbom/format.go
@@ -1,0 +1,111 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sbom
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"strings"
+)
+
+// Format-specific structs for basic parsing
+type cycloneDXJSON struct {
+	BOMFormat    string `json:"bomFormat"`
+	SpecVersion  string `json:"specVersion"`
+	Components   []any  `json:"components"`
+	Dependencies []any  `json:"dependencies"`
+}
+
+type cycloneDXXML struct {
+	XMLName      xml.Name `xml:"bom"`
+	SpecVersion  string   `xml:"version,attr"`
+	Components   []any    `xml:"components>component"`
+	Dependencies []any    `xml:"dependencies>dependency"`
+}
+
+type spdxJSON struct {
+	SPDXID        string `json:"SPDXID"`
+	SpecVersion   string `json:"spdxVersion"`
+	Packages      []any  `json:"packages"`
+	Relationships []any  `json:"relationships"`
+}
+
+func (p *SBOMProcessor) detectJSONFormat(content []byte) (SBOMFormat, bool) {
+	// Try CycloneDX
+	var cdx cycloneDXJSON
+	if err := json.Unmarshal(content, &cdx); err == nil {
+		if strings.EqualFold(cdx.BOMFormat, "CycloneDX") {
+			return FormatCycloneDXJSON, true
+		}
+	}
+
+	// Try SPDX
+	var spdx spdxJSON
+	if err := json.Unmarshal(content, &spdx); err == nil {
+		if strings.HasPrefix(spdx.SPDXID, "SPDXRef-") {
+			return FormatSPDXJSON, true
+		}
+	}
+
+	return FormatUnknown, false
+}
+
+func (p *SBOMProcessor) detectXMLFormat(content []byte) (SBOMFormat, bool) {
+	var cdx cycloneDXXML
+	if err := xml.Unmarshal(content, &cdx); err == nil {
+		return FormatCycloneDXXML, true
+	}
+	return FormatUnknown, false
+}
+
+func (p *SBOMProcessor) parseJSONContent(doc *SBOMDocument) error {
+	switch doc.Format {
+	case FormatCycloneDXJSON:
+		var cdx cycloneDXJSON
+		if err := json.Unmarshal(doc.Content, &cdx); err != nil {
+			return fmt.Errorf("parsing CycloneDX JSON: %w", err)
+		}
+		doc.SpecVersion = cdx.SpecVersion
+
+	case FormatSPDXJSON:
+		var spdx spdxJSON
+		if err := json.Unmarshal(doc.Content, &spdx); err != nil {
+			return fmt.Errorf("parsing SPDX JSON: %w", err)
+		}
+		doc.SpecVersion = spdx.SpecVersion
+	}
+	return nil
+}
+
+func (p *SBOMProcessor) parseXMLContent(doc *SBOMDocument) error {
+	var cdx cycloneDXXML
+	if err := xml.Unmarshal(doc.Content, &cdx); err != nil {
+		return fmt.Errorf("parsing CycloneDX XML: %w", err)
+	}
+	doc.SpecVersion = cdx.SpecVersion
+	return nil
+}
+
+func (p *SBOMProcessor) parseSPDXTagContent(doc *SBOMDocument) error {
+	lines := strings.Split(string(doc.Content), "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(line, "SPDXVersion:") {
+			doc.SpecVersion = strings.TrimSpace(strings.TrimPrefix(line, "SPDXVersion:"))
+			break
+		}
+	}
+	return nil
+}

--- a/pkg/sbom/output.go
+++ b/pkg/sbom/output.go
@@ -1,0 +1,43 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sbom
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// PrettyPrintSBOM prints an SBOM in formatted JSON
+func PrettyPrintSBOM(w io.Writer, Content []byte) error {
+	// First try to unmarshal into a generic interface{} to get the structure
+	var data interface{}
+	if err := json.Unmarshal(Content, &data); err != nil {
+		return fmt.Errorf("failed to parse SBOM content: %w", err)
+	}
+
+	// Create a buffer for pretty printing
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(data); err != nil {
+		return fmt.Errorf("failed to format SBOM: %w", err)
+	}
+
+	// Write the formatted JSON
+	_, err := w.Write(buf.Bytes())
+	return err
+}

--- a/pkg/sbom/processor.go
+++ b/pkg/sbom/processor.go
@@ -1,0 +1,161 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sbom
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// SBOMFormat represents supported SBOM document formats
+type SBOMFormat string
+
+const (
+	FormatCycloneDXJSON SBOMFormat = "CycloneDX-JSON"
+	FormatCycloneDXXML  SBOMFormat = "CycloneDX-XML"
+	FormatSPDXJSON      SBOMFormat = "SPDX-JSON"
+	FormatSPDXTag       SBOMFormat = "SPDX-Tag"
+	FormatUnknown       SBOMFormat = "Unknown"
+)
+
+// SBOMDocument represents a processed SBOM file
+type SBOMDocument struct {
+	Filename    string
+	Format      SBOMFormat
+	Content     []byte
+	SpecVersion string
+}
+
+// SBOMProcessor handles SBOM document processing
+type SBOMProcessor struct {
+	outputDir string
+	verbose   bool
+}
+
+// NewSBOMProcessor creates a new SBOM processor
+func NewSBOMProcessor(outputDir string, verbose bool) *SBOMProcessor {
+	return &SBOMProcessor{
+		// outputdir: represent writing all sbom files inside directory
+		outputDir: outputDir,
+
+		// verbose: represent wrtitng all sbom content to the terminal itself
+		verbose: verbose,
+	}
+}
+
+// ProcessSBOMs processes multiple SBOM files
+func (p *SBOMProcessor) ProcessSBOMs(filenames []string) ([]SBOMDocument, error) {
+	var documents []SBOMDocument
+	var errs []error
+
+	for _, filename := range filenames {
+		doc, err := p.ProcessSBOM(filename)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("processing %s: %w", filename, err))
+			continue
+		}
+		documents = append(documents, doc)
+	}
+
+	if len(errs) > 0 {
+		return documents, fmt.Errorf("encountered %d errors: %v", len(errs), errs[0])
+	}
+
+	return documents, nil
+}
+
+// ProcessSBOM processes a single SBOM file
+func (p *SBOMProcessor) ProcessSBOM(filename string) (SBOMDocument, error) {
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		return SBOMDocument{}, fmt.Errorf("reading file: %w", err)
+	}
+
+	doc := SBOMDocument{
+		Filename: filename,
+		Content:  content,
+	}
+
+	// Detect format and parse content
+	if err := p.detectAndParse(&doc); err != nil {
+		return doc, fmt.Errorf("detecting format: %w", err)
+	}
+
+	// Write processed document if output directory is specified
+	if p.outputDir != "" {
+		if err := p.writeProcessedSBOM(doc); err != nil {
+			return doc, fmt.Errorf("writing output: %w", err)
+		}
+	}
+
+	return doc, nil
+}
+
+// detectAndParse detects the SBOM format and parses its content
+func (p *SBOMProcessor) detectAndParse(doc *SBOMDocument) error {
+	// Try JSON formats first
+	if isJSON(doc.Content) {
+		if format, ok := p.detectJSONFormat(doc.Content); ok {
+			doc.Format = format
+			return p.parseJSONContent(doc)
+		}
+	}
+
+	// Try XML formats
+	if isXML(doc.Content) {
+		if format, ok := p.detectXMLFormat(doc.Content); ok {
+			doc.Format = format
+			return p.parseXMLContent(doc)
+		}
+	}
+
+	// Try SPDX tag-value format
+	if isSPDXTag(doc.Content) {
+		doc.Format = FormatSPDXTag
+		return p.parseSPDXTagContent(doc)
+	}
+
+	doc.Format = FormatUnknown
+	return errors.New("unknown SBOM format")
+}
+
+func (p *SBOMProcessor) writeProcessedSBOM(doc SBOMDocument) error {
+	if err := os.MkdirAll(p.outputDir, 0o755); err != nil {
+		return fmt.Errorf("creating output directory: %w", err)
+	}
+
+	outPath := filepath.Join(p.outputDir, filepath.Base(doc.Filename))
+	return os.WriteFile(outPath, doc.Content, 0o644)
+}
+
+// Helper functions to detect formats
+func isJSON(content []byte) bool {
+	var js json.RawMessage
+	return json.Unmarshal(content, &js) == nil
+}
+
+func isXML(content []byte) bool {
+	return xml.Unmarshal(content, new(interface{})) == nil
+}
+
+func isSPDXTag(content []byte) bool {
+	return strings.Contains(string(content), "SPDXVersion:") ||
+		strings.Contains(string(content), "SPDX-License-Identifier:")
+}

--- a/pkg/source/github/client.go
+++ b/pkg/source/github/client.go
@@ -56,7 +56,7 @@ func NewClient() *Client {
 func (c *Client) GetReleases(ctx context.Context, owner, repo string) ([]Release, error) {
 	// url := fmt.Sprintf("https://github.com/%s/%s/releases", owner, repo)
 	url := fmt.Sprintf("%s/repos/%s/%s/releases", c.baseURL, owner, repo)
-	logger.LogInfo(ctx, "Fetching GitHub Releases", "url", url)
+	logger.LogDebug(ctx, "Fetching GitHub Releases", "url", url)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
@@ -70,7 +70,7 @@ func (c *Client) GetReleases(ctx context.Context, owner, repo string) ([]Release
 		return nil, fmt.Errorf("executing request: %w", err)
 	}
 	defer resp.Body.Close()
-	logger.LogInfo(ctx, "Response ", "body", resp.Body)
+	logger.LogDebug(ctx, "Response ", "body", resp.Body)
 
 	// Read response body for error reporting
 	body, err := io.ReadAll(resp.Body)

--- a/pkg/source/github/download.go
+++ b/pkg/source/github/download.go
@@ -21,6 +21,8 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/interlynk-io/sbommv/pkg/logger"
 )
 
 // Create a worker pool for concurrent downloads
@@ -43,7 +45,7 @@ func GetSBOMs(ctx context.Context, url, version, outputDir string) ([]string, er
 		return nil, fmt.Errorf("no SBOMs found in repository")
 	}
 
-	fmt.Printf("Found %d SBOM(s) in latest release %s\n", len(sboms), sboms[0].Release)
+	logger.LogDebug(ctx, "Total SBOMs found in the release", "version", version, "total sboms", len(sboms))
 
 	// Create output directory if specified and doesn't exist
 	if outputDir != "" {
@@ -99,7 +101,8 @@ func GetSBOMs(ctx context.Context, url, version, outputDir string) ([]string, er
 				reader.Close()
 
 				if work.output != "" {
-					fmt.Printf("Downloaded %s to %s\n", work.sbom.Name, work.output)
+					logger.LogDebug(ctx, "SBOM file", "name", work.sbom.Name, "saved to ", work.output)
+					// fmt.Printf("Downloaded %s to %s\n", work.sbom.Name, work.output)
 				}
 			}
 		}()

--- a/pkg/source/github/scanner.go
+++ b/pkg/source/github/scanner.go
@@ -49,7 +49,7 @@ func (s *SBOMScanner) FindSBOMs(ctx context.Context, url, version string) ([]SBO
 		return nil, fmt.Errorf("parsing GitHub URL: %w", err)
 	}
 
-	logger.LogInfo(ctx, "Parsed github URL values", "url", url, "owner ", owner, "repo", repo)
+	logger.LogDebug(ctx, "Parsed github URL values", "url", url, "owner ", owner, "repo", repo)
 
 	releases, err := s.client.GetReleases(ctx, owner, repo)
 	if err != nil {


### PR DESCRIPTION
This PR add following supports:
- Transferring of sbom from release page for a provided version to a destination adapter. By default, latest is considered.
- Enabling dry mode: it enables printing out  all the fetched SBOMs, in this order`<file path> <spec> <version>` on the terminal.

Command to execute both functionality:

1. Transferring of sbom from release page for a provided version to a destination adapter.
```bash
# Transfer all SBOMs from the Cosign release page for version 2.4.0 to the Interlynk platform under the specified project ID
$ sbommv transfer -D  --input-adapter=github  --in-github-url="https://github.com/sigstore/cosign@v2.4.0" --output-adapter=interlynk  --out-dtrack-url="https://localhost:3000/lynkapi" --out-interlynk-project-id=07fb3477-1273-4996-bc14-fe0c2cc100d7
```

2. Enabling dry mode
```bash
$ go run main.go transfer  --input-adapter=github  --in-github-url="https://github.com/sigstore/cosign@v2.2.4" --output-adapter=interlynk  --out-dtrack-url="https://localhost:3000/lynkapi" --out-interlynk-project-id=07fb3477-1273-4996-bc14-fe0c2cc100d7 --dry-run
```