### PR TITLE
handle adapter to parse flag according to input or output adapter

### DIFF
--- a/pkg/adapter/adapter_factory.go
+++ b/pkg/adapter/adapter_factory.go
@@ -23,14 +23,8 @@ import (
 	"github.com/interlynk-io/sbommv/pkg/logger"
 	"github.com/interlynk-io/sbommv/pkg/source/github"
 	"github.com/interlynk-io/sbommv/pkg/target/interlynk"
+	"github.com/interlynk-io/sbommv/pkg/types"
 	"github.com/spf13/cobra"
-)
-
-type AdapterType string
-
-const (
-	GithubAdapterType    AdapterType = "github"
-	InterlynkAdapterType AdapterType = "interlynk"
 )
 
 // Adapter defines the interface for all adapters
@@ -49,16 +43,16 @@ type Adapter interface {
 }
 
 // NewAdapter initializes and returns the correct adapter
-func NewAdapter(ctx context.Context, adapterType string) (Adapter, error) {
+func NewAdapter(ctx context.Context, adapterType string, role types.AdapterRole) (Adapter, error) {
 	logger.LogInfo(ctx, "Initializing adapter", "adapterType", adapterType)
 
-	switch AdapterType(adapterType) {
+	switch types.AdapterType(adapterType) {
 
-	case GithubAdapterType:
-		return &github.GitHubAdapter{}, nil
+	case types.GithubAdapterType:
+		return &github.GitHubAdapter{Role: role}, nil
 
-	case InterlynkAdapterType:
-		return &interlynk.InterlynkAdapter{}, nil
+	case types.InterlynkAdapterType:
+		return &interlynk.InterlynkAdapter{Role: role}, nil
 
 	default:
 		return nil, fmt.Errorf("unsupported adapter type: %s", adapterType)

--- a/pkg/engine/transfer.go
+++ b/pkg/engine/transfer.go
@@ -28,6 +28,7 @@ import (
 	"github.com/interlynk-io/sbommv/pkg/logger"
 	"github.com/interlynk-io/sbommv/pkg/mvtypes"
 	"github.com/interlynk-io/sbommv/pkg/sbom"
+	"github.com/interlynk-io/sbommv/pkg/types"
 	"github.com/spf13/cobra"
 )
 
@@ -39,14 +40,14 @@ func TransferRun(ctx context.Context, cmd *cobra.Command, config mvtypes.Config)
 	var err error
 
 	// Initialize source adapter
-	inputAdapterInstance, err = adapter.NewAdapter(ctx, config.SourceType)
+	inputAdapterInstance, err = adapter.NewAdapter(ctx, config.SourceType, types.AdapterRole("input"))
 	if err != nil {
 		logger.LogError(ctx, err, "Failed to initialize source adapter")
 		return fmt.Errorf("failed to get source adapter: %w", err)
 	}
 
 	// Initialize destination adapter
-	outputAdapterInstance, err = adapter.NewAdapter(ctx, config.DestinationType)
+	outputAdapterInstance, err = adapter.NewAdapter(ctx, config.DestinationType, types.AdapterRole("output"))
 	if err != nil {
 		logger.LogError(ctx, err, "Failed to initialize destination adapter")
 		return fmt.Errorf("failed to get a destination adapter %v", err)

--- a/pkg/source/github/adapter.go
+++ b/pkg/source/github/adapter.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/interlynk-io/sbommv/pkg/iterator"
+	"github.com/interlynk-io/sbommv/pkg/types"
 	"github.com/interlynk-io/sbommv/pkg/utils"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -36,6 +37,7 @@ type GitHubAdapter struct {
 	BinaryPath  string
 	client      *http.Client
 	GithubToken string
+	Role        types.AdapterRole
 }
 
 type GitHubMethod string
@@ -59,12 +61,19 @@ func (g *GitHubAdapter) AddCommandParams(cmd *cobra.Command) {
 
 // ParseAndValidateParams validates the GitHub adapter params
 func (g *GitHubAdapter) ParseAndValidateParams(cmd *cobra.Command) error {
-	url, _ := cmd.Flags().GetString("in-github-url")
+	var urlFlag, methodFlag string
+
+	if g.Role == types.InputAdapter {
+		urlFlag = "in-github-url"
+		methodFlag = "in-github-method"
+	}
+
+	url, _ := cmd.Flags().GetString(urlFlag)
 	if url == "" {
 		return fmt.Errorf("missing or invalid flag: in-github-url")
 	}
 
-	method, _ := cmd.Flags().GetString("in-github-method")
+	method, _ := cmd.Flags().GetString(methodFlag)
 	if method != "release" && method != "api" && method != "tool" {
 		return fmt.Errorf("missing or invalid flag: in-github-method")
 	}

--- a/pkg/source/github/iterator.go
+++ b/pkg/source/github/iterator.go
@@ -81,7 +81,7 @@ func NewGitHubIterator(ctx context.Context, g *GitHubAdapter) (*GitHubIterator, 
 
 // Next returns the next SBOM from the stored list
 func (it *GitHubIterator) Next(ctx context.Context) (*iterator.SBOM, error) {
-	logger.LogDebug(ctx, "Inside Next")
+	logger.LogDebug(ctx, "Iterating via Next")
 	if it.position >= len(it.sboms) {
 		return nil, io.EOF // No more SBOMs left
 	}

--- a/pkg/target/interlynk/adapter.go
+++ b/pkg/target/interlynk/adapter.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/interlynk-io/sbommv/pkg/iterator"
 	"github.com/interlynk-io/sbommv/pkg/logger"
+	"github.com/interlynk-io/sbommv/pkg/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -33,6 +34,7 @@ type InterlynkAdapter struct {
 	ProjectID string
 	BaseURL   string
 	ApiKey    string
+	Role      types.AdapterRole
 
 	// HTTP client for API requests
 	client *http.Client
@@ -64,12 +66,22 @@ func (i *InterlynkAdapter) AddCommandParams(cmd *cobra.Command) {
 
 // ParseAndValidateParams validates the GitHub adapter params
 func (i *InterlynkAdapter) ParseAndValidateParams(cmd *cobra.Command) error {
-	url, _ := cmd.Flags().GetString("out-interlynk-url")
-	if url == "" {
-		return fmt.Errorf("missing or invalid flag: : out-interlynk-url")
+	var urlFlag, projectIDFlag string
+
+	if i.Role == types.InputAdapter {
+		urlFlag = "in-interlynk-url"
+		projectIDFlag = "in-interlynk-project-id"
+	} else {
+		urlFlag = "out-interlynk-url"
+		projectIDFlag = "out-interlynk-project-id"
 	}
 
-	projectID, _ := cmd.Flags().GetString("out-interlynk-project-id")
+	url, _ := cmd.Flags().GetString(urlFlag)
+	if url == "" {
+		return fmt.Errorf("missing or invalid flag: %s", urlFlag)
+	}
+
+	projectID, _ := cmd.Flags().GetString(projectIDFlag)
 	if projectID == "" {
 		fmt.Println("Warning: No project ID provided, a new project will be created")
 	}

--- a/pkg/types/adapter_types.go
+++ b/pkg/types/adapter_types.go
@@ -1,0 +1,30 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+// AdapterRole defines whether the adapter is input or output
+type AdapterRole string
+
+const (
+	InputAdapter  AdapterRole = "input"
+	OutputAdapter AdapterRole = "output"
+)
+
+type AdapterType string
+
+const (
+	GithubAdapterType    AdapterType = "github"
+	InterlynkAdapterType AdapterType = "interlynk"
+)


### PR DESCRIPTION
This PR introduces 2  major fixes:  
1. **Resolves import cycle issues** by extracting common types (`AdapterRole`, `AdapterType`) into a new package: `types`.  
2. **Fixes strict input/output adapter assumptions**: 
- Right now, our code assumes:
  - GitHub is always the input adapter (--in- flags).
  - Interlynk is always the output adapter (--out- flags).
- But, Interlynk can be both (input & output), meaning:
  - If Interlynk is the input adapter, it should parse --in- flags.
  - If Interlynk is the output adapter, it should parse --out- flags.


Therefore, allowing GitHub and Interlynk adapters to act as both input and output, dynamically.  
