### PR TITLE
fix github adapter tool method

### DIFF
--- a/pkg/source/github/adapter.go
+++ b/pkg/source/github/adapter.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/interlynk-io/sbommv/pkg/iterator"
+	"github.com/interlynk-io/sbommv/pkg/logger"
 	"github.com/interlynk-io/sbommv/pkg/types"
 	"github.com/interlynk-io/sbommv/pkg/utils"
 	"github.com/spf13/cobra"
@@ -76,6 +77,16 @@ func (g *GitHubAdapter) ParseAndValidateParams(cmd *cobra.Command) error {
 	method, _ := cmd.Flags().GetString(methodFlag)
 	if method != "release" && method != "api" && method != "tool" {
 		return fmt.Errorf("missing or invalid flag: in-github-method")
+	}
+
+	if method == "tool" {
+		binaryPath, err := utils.GetBinaryPath()
+		if err != nil {
+			return fmt.Errorf("failed to get Syft binary: %w", err)
+		}
+		fmt.Println("Binary Path: ", binaryPath)
+		g.BinaryPath = binaryPath
+		logger.LogDebug(context.Background(), "Binary Path", "value", g.BinaryPath)
 	}
 
 	token := viper.GetString("GITHUB_TOKEN")


### PR DESCRIPTION
This PR fixes the following:
- Fixes github adapter tool method: As the tool flag `--in-github-method="tool"`  is provided, it clones the syft repo and extract the binary from it. 