### PR TITLE
support generating sbom for particular branch using tool method

### DIFF
--- a/pkg/iterator/iterator.go
+++ b/pkg/iterator/iterator.go
@@ -25,6 +25,7 @@ type SBOM struct {
 	Data    []byte // SBOM data stored in memory (nil if using Path)
 	Repo    string // Repository URL (helps track multi-repo processing)
 	Version string // Version of the SBOM (e.g., "latest" or "v1.2.3")
+	Branch  string // github repo main, master, or any specific branch
 }
 
 // SBOMIterator provides a way to lazily fetch SBOMs one by one

--- a/pkg/source/github/adapter.go
+++ b/pkg/source/github/adapter.go
@@ -72,6 +72,7 @@ const (
 func (g *GitHubAdapter) AddCommandParams(cmd *cobra.Command) {
 	cmd.Flags().String("in-github-url", "", "GitHub repository URL")
 	cmd.Flags().String("in-github-method", "api", "GitHub method: release, api, or tool")
+	cmd.Flags().String("in-github-branch", "", "Github repository branch")
 
 	// Updated to StringSlice to support multiple values (comma-separated)
 	cmd.Flags().StringSlice("in-github-include-repos", nil, "Include only these repositories e.g sbomqs,sbomasm")
@@ -83,13 +84,14 @@ func (g *GitHubAdapter) AddCommandParams(cmd *cobra.Command) {
 
 // ParseAndValidateParams validates the GitHub adapter params
 func (g *GitHubAdapter) ParseAndValidateParams(cmd *cobra.Command) error {
-	var urlFlag, methodFlag, includeFlag, excludeFlag string
+	var urlFlag, methodFlag, includeFlag, excludeFlag, githubBranchFlag string
 
 	if g.Role == types.InputAdapter {
 		urlFlag = "in-github-url"
 		methodFlag = "in-github-method"
 		includeFlag = "in-github-include-repos"
 		excludeFlag = "in-github-exclude-repos"
+		githubBranchFlag = "in-github-branch"
 	}
 
 	// Extract GitHub URL
@@ -102,6 +104,8 @@ func (g *GitHubAdapter) ParseAndValidateParams(cmd *cobra.Command) error {
 	if method != "release" && method != "api" && method != "tool" {
 		return fmt.Errorf("missing or invalid flag: %s", methodFlag)
 	}
+
+	branch, _ := cmd.Flags().GetString(githubBranchFlag)
 
 	includeRepos, _ := cmd.Flags().GetStringSlice(includeFlag)
 	excludeRepos, _ := cmd.Flags().GetStringSlice(excludeFlag)
@@ -139,7 +143,7 @@ func (g *GitHubAdapter) ParseAndValidateParams(cmd *cobra.Command) error {
 		return fmt.Errorf("version flag is not supported for GitHub API method")
 	}
 
-	//Assign extracted values to struct
+	// Assign extracted values to struct
 	if version == "" {
 		version = "latest"
 		g.URL = githubURL
@@ -149,6 +153,7 @@ func (g *GitHubAdapter) ParseAndValidateParams(cmd *cobra.Command) error {
 
 	g.Owner = owner
 	g.Repo = repo
+	g.Branch = branch
 	g.Version = version
 	g.Method = method
 	g.GithubToken = token
@@ -160,6 +165,7 @@ func (g *GitHubAdapter) ParseAndValidateParams(cmd *cobra.Command) error {
 	logger.LogDebug(cmd.Context(), "Parsed GitHub parameters",
 		"url", g.URL,
 		"owner", g.Owner,
+		"branch", g.Branch,
 		"repo", g.Repo,
 		"version", g.Version,
 		"include_repos", g.IncludeRepos,

--- a/pkg/source/github/client.go
+++ b/pkg/source/github/client.go
@@ -72,6 +72,7 @@ type Client struct {
 	Repo         string
 	Version      string
 	Method       string
+	Branch       string
 	token        string
 }
 
@@ -85,6 +86,7 @@ func NewClient(g *GitHubAdapter) *Client {
 		Method:     g.Method,
 		Owner:      g.Owner,
 		Repo:       g.Repo,
+		Branch:     g.Branch,
 	}
 }
 

--- a/pkg/source/github/iterator.go
+++ b/pkg/source/github/iterator.go
@@ -130,7 +130,7 @@ func (it *GitHubIterator) fetchSBOMFromTool(ctx *tcontext.TransferMetadata) erro
 	repoDir := filepath.Join(os.TempDir(), fmt.Sprintf("%s-%s", it.client.Repo, it.client.Version))
 	defer os.RemoveAll(repoDir)
 
-	if err := CloneRepoWithGit(ctx, it.client.RepoURL, repoDir); err != nil {
+	if err := CloneRepoWithGit(ctx, it.client.RepoURL, it.client.Branch, repoDir); err != nil {
 		return fmt.Errorf("failed to clone the repository: %w", err)
 	}
 
@@ -149,12 +149,12 @@ func (it *GitHubIterator) fetchSBOMFromTool(ctx *tcontext.TransferMetadata) erro
 		return fmt.Errorf("generate SBOM with zero file data: %w", err)
 	}
 
-	// store data
 	it.sboms = append(it.sboms, &iterator.SBOM{
 		Path:    "",
 		Data:    sbomBytes,
 		Repo:    fmt.Sprintf("%s/%s", it.client.Owner, it.client.Repo),
 		Version: it.client.Version,
+		Branch:  it.client.Branch,
 	})
 	logger.LogDebug(ctx.Context, "SBOM successfully stored in memory", "repository", it.client.RepoURL)
 	return nil

--- a/pkg/utils/transfer.go
+++ b/pkg/utils/transfer.go
@@ -22,6 +22,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/interlynk-io/sbommv/pkg/logger"
 )
 
 func GetBinaryPath() (string, error) {
@@ -87,7 +89,8 @@ func CloneRepoWithGit(ctx context.Context, repoURL, targetDir string) error {
 		return fmt.Errorf("git clone failed: %w", err)
 	}
 
-	fmt.Println("✅ Repository successfully cloned using Git.")
+	logger.LogDebug(ctx, "Repository successfully cloned using git", "repo", repoURL)
+
 	return nil
 }
 


### PR DESCRIPTION
**This PR add the following changes**:

- Added support for fetching SBOMs from a specific branch in the GitHub Tool Method.
- Adds the separate flag for branch : `in-github-branch`.
  - If branch is provided, then it will clone that specific branch and generates SBOM.
  - If branch is not provided, which is by default empty, then in that case, it will pull up repo for default branch

**NOTE**:
- This branch method only supports for `tool` method, whereas `api` and `release` won't support.

### Description:

#### Why **API** and **Release** Methods Don't Support Branch Selection ?
- **GitHub API Method**: The dependency graph only provides SBOMs for the default branch and does not allow fetching SBOMs for arbitrary branches.
- **GitHub Release Method**: SBOMs are generated for tagged releases, which are typically based on the main branch and do not support fetching from specific branches.

#### Why Tool Method Supports Branch Selection ?
- The Tool Method clones the repository locally, allowing us to check out any specific branch and generate an SBOM from that branch using an external tool like Syft.



