### PR TITLE
add filename and discard unnecessary cloning o/p

### DIFF
--- a/pkg/engine/transfer.go
+++ b/pkg/engine/transfer.go
@@ -96,7 +96,7 @@ func TransferRun(ctx context.Context, cmd *cobra.Command, config mvtypes.Config)
 func dryMode(ctx context.Context, iterator iterator.SBOMIterator, outputDir string) error {
 	logger.LogDebug(ctx, "Dry-run mode enabled. Preparing to display SBOM details.")
 
-	processor := sbom.NewSBOMProcessor(outputDir, false) // No need for output directory in dry-run mode
+	processor := sbom.NewSBOMProcessor(outputDir, true) // No need for output directory in dry-run mode
 	sbomCount := 0
 
 	for {
@@ -111,7 +111,7 @@ func dryMode(ctx context.Context, iterator iterator.SBOMIterator, outputDir stri
 
 		logger.LogDebug(ctx, "Processing SBOM from memory", "repo", sbom.Repo, "version", sbom.Version)
 
-		doc, err := processor.ProcessSBOMs(sbom.Data, sbom.Repo)
+		doc, err := processor.ProcessSBOMs(sbom.Data, sbom.Repo, sbom.Path)
 		if err != nil {
 			logger.LogError(ctx, err, "Failed to process SBOM")
 			continue
@@ -125,7 +125,7 @@ func dryMode(ctx context.Context, iterator iterator.SBOMIterator, outputDir stri
 		}
 
 		sbomCount++
-		logger.LogDebug(ctx, fmt.Sprintf("%d. Repo: %s | Format: %s | SpecVersion: %s", sbomCount, sbom.Repo, doc.Format, doc.SpecVersion))
+		fmt.Printf("%d. Repo: %s | Format: %s | SpecVersion: %s | Filename: %s \n", sbomCount, sbom.Repo, doc.Format, doc.SpecVersion, doc.Filename)
 	}
 
 	logger.LogDebug(ctx, "Dry-run mode completed", "total_sboms_processed", sbomCount)

--- a/pkg/sbom/processor.go
+++ b/pkg/sbom/processor.go
@@ -64,13 +64,17 @@ func NewSBOMProcessor(outputDir string, verbose bool) *SBOMProcessor {
 }
 
 // ProcessSBOMFromBytes processes an SBOM directly from memory
-func (p *SBOMProcessor) ProcessSBOMs(content []byte, repoName string) (SBOMDocument, error) {
+func (p *SBOMProcessor) ProcessSBOMs(content []byte, repoName, filePath string) (SBOMDocument, error) {
 	if len(content) == 0 {
 		return SBOMDocument{}, errors.New("empty SBOM content")
 	}
+	if filePath == "" {
+		filePath = "N/A"
+	}
 
 	doc := SBOMDocument{
-		Filename: fmt.Sprintf("%s.sbom.json", repoName), // Use repo name as filename
+		// Filename: fmt.Sprintf("%s.sbom.json", repoName), // Use repo name as filename
+		Filename: filePath,
 		Content:  content,
 	}
 

--- a/pkg/source/github/client.go
+++ b/pkg/source/github/client.go
@@ -60,7 +60,12 @@ type SBOMAsset struct {
 
 // VersionedSBOMs maps versions to their respective SBOMs in that version
 // type VersionedSBOMs map[string][]string
-type VersionedSBOMs map[string][][]byte
+type VersionedSBOMs map[string][]SBOMData
+
+type SBOMData struct {
+	Content  []byte
+	Filename string
+}
 
 // Client interacts with the GitHub API
 type Client struct {
@@ -317,9 +322,13 @@ func (c *Client) downloadSBOMs(ctx *tcontext.TransferMetadata, sboms []SBOMAsset
 				return
 			}
 
-			// Store SBOM content in memory
+			versionedSBOM := SBOMData{
+				Content:  sbomData,
+				Filename: sbom.Name,
+			}
+
 			mu.Lock()
-			versionedSBOMs[sbom.Release] = append(versionedSBOMs[sbom.Release], sbomData)
+			versionedSBOMs[sbom.Release] = append(versionedSBOMs[sbom.Release], versionedSBOM)
 			mu.Unlock()
 
 			logger.LogDebug(ctx.Context, "SBOM fetched and stored in memory", "name", sbom.Name)

--- a/pkg/source/github/iterator.go
+++ b/pkg/source/github/iterator.go
@@ -112,8 +112,8 @@ func (it *GitHubIterator) fetchSBOMFromReleases(ctx *tcontext.TransferMetadata) 
 	for version, sbomDataList := range sbomFiles {
 		for _, sbomData := range sbomDataList { // sbomPath is a string (file path)
 			it.sboms = append(it.sboms, &iterator.SBOM{
-				Path:    "", // No file path, storing in memory
-				Data:    sbomData,
+				Path:    sbomData.Filename,
+				Data:    sbomData.Content,
 				Repo:    fmt.Sprintf("%s/%s", it.client.Owner, it.client.Repo),
 				Version: version,
 			})


### PR DESCRIPTION
This PR adds the following changes:
- Adds the filename for SBOMs in dry-mode
  - for github api and release mthod, filename is N/A.
  - whereas for github tool method, filename is same as on release page
- Remove unnecessary git cloning o/p.
