### PR TITLE
Refractor/improve redability

### DIFF
--- a/pkg/engine/transfer.go
+++ b/pkg/engine/transfer.go
@@ -75,36 +75,7 @@ func TransferRun(ctx context.Context, cmd *cobra.Command, config mvtypes.Config)
 
 	if config.DryRun {
 		logger.LogDebug(transferCtx.Context, "Dry-run mode enabled: Displaying retrieved SBOMs", "values", config.DryRun)
-
-		// Step 1: Store SBOMs in memory (avoid consuming iterator)
-		var sboms []*iterator.SBOM
-		for {
-			sbom, err := sbomIterator.Next(transferCtx.Context)
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				logger.LogError(transferCtx.Context, err, "Error retrieving SBOM from iterator")
-				continue
-			}
-			sboms = append(sboms, sbom)
-		}
-		fmt.Println()
-
-		fmt.Println("-----------------🌐 INPUT ADAPTER DRY-RUN OUTPUT 🌐-----------------")
-		// Step 2: Use stored SBOMs for input dry-run
-		if err := inputAdapterInstance.DryRun(transferCtx, iterator.NewMemoryIterator(sboms)); err != nil {
-			return fmt.Errorf("failed to execute dry-run mode for input adapter: %v", err)
-		}
-		fmt.Println()
-		fmt.Println("-----------------🌐 OUTPUT ADAPTER DRY-RUN OUTPUT 🌐-----------------")
-
-		// Step 3: Use the same stored SBOMs for output dry-run
-		if err := outputAdapterInstance.DryRun(transferCtx, iterator.NewMemoryIterator(sboms)); err != nil {
-			return fmt.Errorf("failed to execute dry-run mode for output adapter: %v", err)
-		}
-
-		return nil
+		dryRun(*transferCtx, sbomIterator, inputAdapterInstance, outputAdapterInstance)
 	}
 
 	// Process & Upload SBOMs Sequentially
@@ -113,5 +84,37 @@ func TransferRun(ctx context.Context, cmd *cobra.Command, config mvtypes.Config)
 	}
 
 	logger.LogDebug(ctx, "SBOM transfer process completed successfully ✅")
+	return nil
+}
+
+func dryRun(ctx tcontext.TransferMetadata, sbomIterator iterator.SBOMIterator, input, output adapter.Adapter) error {
+	// Step 1: Store SBOMs in memory (avoid consuming iterator)
+	var sboms []*iterator.SBOM
+	for {
+		sbom, err := sbomIterator.Next(ctx.Context)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			logger.LogError(ctx.Context, err, "Error retrieving SBOM from iterator")
+			continue
+		}
+		sboms = append(sboms, sbom)
+	}
+	fmt.Println()
+
+	fmt.Println("-----------------🌐 INPUT ADAPTER DRY-RUN OUTPUT 🌐-----------------")
+	// Step 2: Use stored SBOMs for input dry-run
+	if err := input.DryRun(&ctx, iterator.NewMemoryIterator(sboms)); err != nil {
+		return fmt.Errorf("failed to execute dry-run mode for input adapter: %v", err)
+	}
+	fmt.Println()
+	fmt.Println("-----------------🌐 OUTPUT ADAPTER DRY-RUN OUTPUT 🌐-----------------")
+
+	// Step 3: Use the same stored SBOMs for output dry-run
+	if err := output.DryRun(&ctx, iterator.NewMemoryIterator(sboms)); err != nil {
+		return fmt.Errorf("failed to execute dry-run mode for output adapter: %v", err)
+	}
+
 	return nil
 }

--- a/pkg/engine/transfer.go
+++ b/pkg/engine/transfer.go
@@ -39,18 +39,17 @@ func TransferRun(ctx context.Context, cmd *cobra.Command, config mvtypes.Config)
 	var outputAdapterInstance adapter.Adapter
 	var err error
 
-	// Initialize source adapter
-	inputAdapterInstance, err = adapter.NewAdapter(transferCtx, config.SourceType, types.AdapterRole("input"))
+	adapters, err := adapter.NewAdapter(transferCtx, config)
 	if err != nil {
-		logger.LogError(transferCtx.Context, err, "Failed to initialize source adapter")
-		return fmt.Errorf("failed to get source adapter: %w", err)
+		return fmt.Errorf("failed to initialize adapters: %v", err)
 	}
 
-	// Initialize destination adapter
-	outputAdapterInstance, err = adapter.NewAdapter(transferCtx, config.DestinationType, types.AdapterRole("output"))
-	if err != nil {
-		logger.LogError(transferCtx.Context, err, "Failed to initialize destination adapter")
-		return fmt.Errorf("failed to get a destination adapter %v", err)
+	// Extract input and output adapters using predefined roles
+	inputAdapterInstance = adapters[types.InputAdapterRole]
+	outputAdapterInstance = adapters[types.OutputAdapterRole]
+
+	if inputAdapterInstance == nil || outputAdapterInstance == nil {
+		return fmt.Errorf("failed to initialize both input and output adapters")
 	}
 
 	// Parse and validate input adapter parameters

--- a/pkg/source/github/adapter.go
+++ b/pkg/source/github/adapter.go
@@ -214,6 +214,7 @@ func (g *GitHubAdapter) ParseAndValidateParams(cmd *cobra.Command) error {
 		"include_repos", g.IncludeRepos,
 		"exclude_repos", g.ExcludeRepos,
 		"method", g.Method,
+		"token", g.GithubToken,
 	)
 	return nil
 }
@@ -440,7 +441,7 @@ func (g *GitHubAdapter) DryRun(ctx *tcontext.TransferMetadata, iterator iterator
 		}
 
 		sbomCount++
-		fmt.Printf(" - 📁 Repo: %s-%s | Format: %s | SpecVersion: %s | Filename: %s \n", sbom.Repo, sbom.Version, doc.Format, doc.SpecVersion, doc.Filename)
+		fmt.Printf(" - 📁 Repo: %s | Format: %s | SpecVersion: %s | Filename: %s \n", sbom.Repo, doc.Format, doc.SpecVersion, doc.Filename)
 
 		// logger.LogInfo(ctx.Context, fmt.Sprintf("%d. Repo: %s | Format: %s | SpecVersion: %s | Filename: %s",
 		// 	sbomCount, sbom.Repo, doc.Format, doc.SpecVersion, doc.Filename))

--- a/pkg/source/github/adapter.go
+++ b/pkg/source/github/adapter.go
@@ -312,9 +312,13 @@ func (g *GitHubAdapter) fetchSBOMsConcurrently(ctx *tcontext.TransferMetadata, r
 			defer wg.Done()
 			g.Repo = repo
 			g.client.Repo = repo
-			iter, err := NewGitHubIterator(ctx, g, repo)
+
+			iter := NewGitHubIterator(ctx, g, repo)
+
+			// Fetch SBOMs separately
+			err := iter.HandleSBOMFetchingViaIterator(ctx, GitHubMethod(g.Method))
 			if err != nil {
-				logger.LogError(ctx.Context, err, "Failed to fetch SBOMs for repo", "repo", repo)
+				logger.LogDebug(ctx.Context, "Failed to fetch SBOMs for repo", "repo", repo)
 				return
 			}
 			for {
@@ -355,8 +359,10 @@ func (g *GitHubAdapter) fetchSBOMsSequentially(ctx *tcontext.TransferMetadata, r
 
 		logger.LogDebug(ctx.Context, "Fetching SBOMs sequentially", "repo", repo)
 
-		// Fetch SBOMs for the current repository
-		iter, err := NewGitHubIterator(ctx, g, repo)
+		iter := NewGitHubIterator(ctx, g, repo)
+
+		// Fetch SBOMs separately
+		err := iter.HandleSBOMFetchingViaIterator(ctx, GitHubMethod(g.Method))
 		if err != nil {
 			logger.LogInfo(ctx.Context, "Failed to fetch SBOMs for", "repo", repo)
 			continue

--- a/pkg/source/github/adapter.go
+++ b/pkg/source/github/adapter.go
@@ -91,12 +91,19 @@ func (g *GitHubAdapter) ParseAndValidateParams(cmd *cobra.Command) error {
 		invalidFlags                                                    []string
 	)
 
-	if g.Role == types.InputAdapter {
+	switch g.Role {
+	case types.InputAdapterRole:
 		urlFlag = "in-github-url"
 		methodFlag = "in-github-method"
 		includeFlag = "in-github-include-repos"
 		excludeFlag = "in-github-exclude-repos"
 		githubBranchFlag = "in-github-branch"
+
+	case types.OutputAdapterRole:
+		return fmt.Errorf("The GitHub adapter doesn't support output adapter functionalities.")
+
+	default:
+		return fmt.Errorf("The adapter is neither an input type nor an output type")
 	}
 
 	// Extract GitHub URL

--- a/pkg/source/github/client.go
+++ b/pkg/source/github/client.go
@@ -447,6 +447,14 @@ func (c *Client) GetAllRepositories(ctx *tcontext.TransferMetadata) ([]string, e
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 
+	// Add authentication only if a token is provided
+	if c.Token != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.Token))
+	}
+
+	// Set required headers
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("fetching repositories: %w", err)

--- a/pkg/target/interlynk/adapter.go
+++ b/pkg/target/interlynk/adapter.go
@@ -275,7 +275,7 @@ func (i *InterlynkAdapter) DryRun(ctx *tcontext.TransferMetadata, sbomIterator i
 		}
 
 		// Identify project name (repo-version)
-		projectKey := fmt.Sprintf("%s-%s", sbom.Repo, sbom.Version)
+		projectKey := fmt.Sprintf("%s", sbom.Repo)
 		projectSBOMs[projectKey] = append(projectSBOMs[projectKey], doc)
 		totalSBOMs++
 		uniqueFormats[string(doc.Format)] = struct{}{}

--- a/pkg/target/interlynk/adapter.go
+++ b/pkg/target/interlynk/adapter.go
@@ -71,14 +71,18 @@ func (i *InterlynkAdapter) ParseAndValidateParams(cmd *cobra.Command) error {
 	var missingFlags []string
 	var invalidFlags []string
 
-	if i.Role == types.InputAdapter {
-		urlFlag = "in-interlynk-url"
-		projectNameFlag = "in-interlynk-project-name"
-		projectEnvFlag = "in-interlynk-project-env"
-	} else {
+	switch i.Role {
+
+	case types.InputAdapterRole:
+		return fmt.Errorf("The Interlynk adapter doesn't support input adapter functionalities.")
+
+	case types.OutputAdapterRole:
 		urlFlag = "out-interlynk-url"
 		projectNameFlag = "out-interlynk-project-name"
 		projectEnvFlag = "out-interlynk-project-env"
+
+	default:
+		return fmt.Errorf("The adapter is neither an input type nor an output type")
 	}
 
 	// Get flags

--- a/pkg/types/adapter_types.go
+++ b/pkg/types/adapter_types.go
@@ -18,8 +18,8 @@ package types
 type AdapterRole string
 
 const (
-	InputAdapter  AdapterRole = "input"
-	OutputAdapter AdapterRole = "output"
+	InputAdapterRole  AdapterRole = "input"
+	OutputAdapterRole AdapterRole = "output"
 )
 
 type AdapterType string


### PR DESCRIPTION
This PR add the following changes:

- dry-mode
   - Introduced `dryRun()` function to separate dry-run logic from the main transfer flow.  
   - remove version from project name in dry-mode 

- Refactored Adapter Role Handling 
   - Removed explicit `role` parameter, deriving it dynamically from `config`.  

-  Applied SOLID Principles to `NewGitHubIterator`  
   - `NewGitHubIterator()` only initializes the iterator.  
   - `HandleSBOMFetchingViaIterator()` separates SBOM retrieval logic from NewGitHubIterator() to follow SOLID principle, as it's says one function for one reason.  
   
  - Fix token issue while fetching all repositories
