### PR TITLE
Refractor/follow solid principle for GitHub n interlynk

### DIFF
--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -1,0 +1,64 @@
+// pkg/reporter/reporter.go
+package reporter
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/interlynk-io/sbommv/pkg/iterator"
+	"github.com/interlynk-io/sbommv/pkg/logger"
+	"github.com/interlynk-io/sbommv/pkg/sbom"
+)
+
+type SBOMReporter struct {
+	verbose   bool
+	outputDir string
+}
+
+func NewSBOMReporter(verbose bool, outputDir string) *SBOMReporter {
+	return &SBOMReporter{verbose: verbose, outputDir: outputDir}
+}
+
+func (r *SBOMReporter) DryRun(ctx context.Context, iter iterator.SBOMIterator) error {
+	logger.LogDebug(ctx, "Dry-run mode: Displaying SBOMs")
+	processor := sbom.NewSBOMProcessor(r.outputDir, r.verbose)
+	sbomCount := 0
+	fmt.Println("\n📦 Details of all Fetched SBOMs")
+
+	for {
+		sbom, err := iter.Next(ctx)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			logger.LogError(ctx, err, "Error retrieving SBOM from iterator")
+			return err // Propagate instead of swallowing
+		}
+		processor.Update(sbom.Data, sbom.Namespace, sbom.Path)
+		doc, err := processor.ProcessSBOMs()
+		if err != nil {
+			logger.LogError(ctx, err, "Failed to process SBOM")
+			return err
+		}
+		if r.outputDir != "" {
+			if err := processor.WriteSBOM(doc, sbom.Namespace); err != nil {
+				logger.LogError(ctx, err, "Failed to write SBOM")
+				return err
+			}
+		}
+		if r.verbose {
+			fmt.Printf("\n-------------------- 📜 SBOM Content --------------------\n")
+			fmt.Printf("📂 Filename: %s\n", doc.Filename)
+			fmt.Printf("📦 Format: %s | SpecVersion: %s\n\n", doc.Format, doc.SpecVersion)
+			fmt.Println(string(doc.Content))
+			fmt.Println("------------------------------------------------------")
+		}
+		sbomCount++
+		fmt.Printf(" - 📁 Repo: %s | Format: %s | SpecVersion: %s | Filename: %s \n",
+			sbom.Namespace, doc.Format, doc.SpecVersion, doc.Filename)
+	}
+	fmt.Printf("📊 Total SBOMs are: %d\n", sbomCount)
+	logger.LogDebug(ctx, "Dry-run completed", "total_sboms", sbomCount)
+	return nil
+}

--- a/pkg/source/github/client.go
+++ b/pkg/source/github/client.go
@@ -97,6 +97,20 @@ func NewClient(g *GitHubAdapter) *Client {
 	}
 }
 
+type GitHubAPI interface {
+	GetAllRepositories(ctx *tcontext.TransferMetadata) ([]string, error)
+	FetchSBOMFromAPI(ctx *tcontext.TransferMetadata) ([]byte, error)
+	GetSBOMs(ctx *tcontext.TransferMetadata) (VersionedSBOMs, error)
+	updateRepo(repo string)
+	GetRepo() string // Added to access the current repo
+}
+
+func (c *Client) GetRepo() string {
+	return c.Repo
+}
+
+var _ GitHubAPI = (*Client)(nil) // Ensure Client implements it
+
 // FindSBOMs gets all releases assets from github release page
 // filter out the particular provided release asset and
 // extract SBOMs from that

--- a/pkg/source/github/client.go
+++ b/pkg/source/github/client.go
@@ -87,13 +87,13 @@ func NewClient(g *GitHubAdapter) *Client {
 	return &Client{
 		httpClient: &http.Client{},
 		BaseURL:    "https://api.github.com",
-		RepoURL:    g.URL,
-		Version:    g.Version,
-		Method:     g.Method,
-		Owner:      g.Owner,
-		Repo:       g.Repo,
-		Branch:     g.Branch,
-		Token:      g.GithubToken,
+		RepoURL:    g.config.URL,
+		Version:    g.config.Version,
+		Method:     g.config.Method,
+		Owner:      g.config.Owner,
+		Repo:       g.config.Repo,
+		Branch:     g.config.Branch,
+		Token:      g.config.GithubToken,
 	}
 }
 

--- a/pkg/source/github/config.go
+++ b/pkg/source/github/config.go
@@ -15,6 +15,12 @@
 // pkg/source/github/config.go
 package github
 
+const (
+	MethodAPI      = "api"
+	MethodReleases = "release"
+	MethodTool     = "tool"
+)
+
 // GitHubConfig holds all configuration data for the GitHub adapter
 type GitHubConfig struct {
 	URL          string

--- a/pkg/source/github/config.go
+++ b/pkg/source/github/config.go
@@ -1,0 +1,36 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// pkg/source/github/config.go
+package github
+
+// GitHubConfig holds all configuration data for the GitHub adapter
+type GitHubConfig struct {
+	URL          string
+	Repo         string
+	Owner        string
+	Version      string
+	Branch       string
+	Method       string
+	BinaryPath   string
+	GithubToken  string
+	IncludeRepos []string
+	ExcludeRepos []string
+}
+
+func NewGitHubConfig() *GitHubConfig {
+	return &GitHubConfig{
+		Version: "latest", // Default value
+	}
+}

--- a/pkg/source/github/fetcher.go
+++ b/pkg/source/github/fetcher.go
@@ -15,19 +15,23 @@
 package github
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/interlynk-io/sbommv/pkg/iterator"
 	"github.com/interlynk-io/sbommv/pkg/tcontext"
 )
 
 // SBOMFetcher defines the strategy for fetching SBOMs
 type SBOMFetcher interface {
-	Fetch(ctx *tcontext.TransferMetadata, client *Client, config *GitHubConfig) (iterator.SBOMIterator, error)
+	Fetch(ctx *tcontext.TransferMetadata, client GitHubAPI, config *GitHubConfig) (iterator.SBOMIterator, error)
 }
 
 // APIFetcher fetches SBOMs using GitHub's dependency graph API
 type APIFetcher struct{}
 
-func (f *APIFetcher) Fetch(ctx *tcontext.TransferMetadata, client *Client, config *GitHubConfig) (iterator.SBOMIterator, error) {
+func (f *APIFetcher) Fetch(ctx *tcontext.TransferMetadata, client GitHubAPI, config *GitHubConfig) (iterator.SBOMIterator, error) {
 	iter := NewGitHubIterator(ctx, client, config)
 	if err := iter.fetchSBOMFromAPI(ctx); err != nil {
 		return nil, err
@@ -38,7 +42,7 @@ func (f *APIFetcher) Fetch(ctx *tcontext.TransferMetadata, client *Client, confi
 // ReleasesFetcher fetches SBOMs from GitHub release assets
 type ReleasesFetcher struct{}
 
-func (f *ReleasesFetcher) Fetch(ctx *tcontext.TransferMetadata, client *Client, config *GitHubConfig) (iterator.SBOMIterator, error) {
+func (f *ReleasesFetcher) Fetch(ctx *tcontext.TransferMetadata, client GitHubAPI, config *GitHubConfig) (iterator.SBOMIterator, error) {
 	iter := NewGitHubIterator(ctx, client, config)
 	if err := iter.fetchSBOMFromReleases(ctx); err != nil {
 		return nil, err
@@ -47,19 +51,45 @@ func (f *ReleasesFetcher) Fetch(ctx *tcontext.TransferMetadata, client *Client, 
 }
 
 // ToolFetcher generates SBOMs using an external tool like Syft
-type ToolFetcher struct{}
+type ToolFetcher struct {
+	generator SBOMGenerator
+}
 
-func (f *ToolFetcher) Fetch(ctx *tcontext.TransferMetadata, client *Client, config *GitHubConfig) (iterator.SBOMIterator, error) {
+func NewToolFetcher(generator SBOMGenerator) *ToolFetcher {
+	return &ToolFetcher{generator: generator}
+}
+
+func (f *ToolFetcher) Fetch(ctx *tcontext.TransferMetadata, client GitHubAPI, config *GitHubConfig) (iterator.SBOMIterator, error) {
 	iter := NewGitHubIterator(ctx, client, config)
-	if err := iter.fetchSBOMFromTool(ctx); err != nil {
+	repoDir := filepath.Join(os.TempDir(), fmt.Sprintf("%s-%s", config.Repo, config.Version))
+	defer os.RemoveAll(repoDir)
+
+	if err := CloneRepoWithGit(ctx, config.URL, config.Branch, repoDir); err != nil {
 		return nil, err
 	}
+
+	sbomFile, err := f.generator.Generate(ctx, repoDir, config.BinaryPath)
+	if err != nil {
+		return nil, err
+	}
+
+	sbomBytes, err := os.ReadFile(sbomFile)
+	if err != nil {
+		return nil, err
+	}
+
+	iter.sboms = append(iter.sboms, &iterator.SBOM{
+		Data:      sbomBytes,
+		Namespace: fmt.Sprintf("%s/%s", config.Owner, config.Repo),
+		Version:   config.Version,
+		Branch:    config.Branch,
+	})
 	return iter, nil
 }
 
 // fetcherFactory maps method names to their fetcher implementations
 var fetcherFactory = map[string]SBOMFetcher{
-	"api":     &APIFetcher{},
-	"release": &ReleasesFetcher{},
-	"tool":    &ToolFetcher{},
+	MethodAPI:      &APIFetcher{},
+	MethodReleases: &ReleasesFetcher{},
+	MethodTool:     NewToolFetcher(&SyftGenerator{}),
 }

--- a/pkg/source/github/fetcher.go
+++ b/pkg/source/github/fetcher.go
@@ -1,0 +1,65 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+import (
+	"github.com/interlynk-io/sbommv/pkg/iterator"
+	"github.com/interlynk-io/sbommv/pkg/tcontext"
+)
+
+// SBOMFetcher defines the strategy for fetching SBOMs
+type SBOMFetcher interface {
+	Fetch(ctx *tcontext.TransferMetadata, client *Client, config *GitHubConfig) (iterator.SBOMIterator, error)
+}
+
+// APIFetcher fetches SBOMs using GitHub's dependency graph API
+type APIFetcher struct{}
+
+func (f *APIFetcher) Fetch(ctx *tcontext.TransferMetadata, client *Client, config *GitHubConfig) (iterator.SBOMIterator, error) {
+	iter := NewGitHubIterator(ctx, client, config)
+	if err := iter.fetchSBOMFromAPI(ctx); err != nil {
+		return nil, err
+	}
+	return iter, nil
+}
+
+// ReleasesFetcher fetches SBOMs from GitHub release assets
+type ReleasesFetcher struct{}
+
+func (f *ReleasesFetcher) Fetch(ctx *tcontext.TransferMetadata, client *Client, config *GitHubConfig) (iterator.SBOMIterator, error) {
+	iter := NewGitHubIterator(ctx, client, config)
+	if err := iter.fetchSBOMFromReleases(ctx); err != nil {
+		return nil, err
+	}
+	return iter, nil
+}
+
+// ToolFetcher generates SBOMs using an external tool like Syft
+type ToolFetcher struct{}
+
+func (f *ToolFetcher) Fetch(ctx *tcontext.TransferMetadata, client *Client, config *GitHubConfig) (iterator.SBOMIterator, error) {
+	iter := NewGitHubIterator(ctx, client, config)
+	if err := iter.fetchSBOMFromTool(ctx); err != nil {
+		return nil, err
+	}
+	return iter, nil
+}
+
+// fetcherFactory maps method names to their fetcher implementations
+var fetcherFactory = map[string]SBOMFetcher{
+	"api":     &APIFetcher{},
+	"release": &ReleasesFetcher{},
+	"tool":    &ToolFetcher{},
+}

--- a/pkg/source/github/iterator.go
+++ b/pkg/source/github/iterator.go
@@ -36,7 +36,7 @@ type GitHubIterator struct {
 
 // NewGitHubIterator initializes and returns a new GitHubIterator instance
 func NewGitHubIterator(ctx *tcontext.TransferMetadata, g *GitHubAdapter, repo string) *GitHubIterator {
-	logger.LogDebug(ctx.Context, "Initializing GitHub Iterator", "repo", g.URL, "method", g.Method, "repo", repo)
+	logger.LogDebug(ctx.Context, "Initializing GitHub Iterator", "repo", g.config.URL, "method", g.config.Method, "repo", repo)
 
 	g.client.updateRepo(repo)
 
@@ -44,7 +44,7 @@ func NewGitHubIterator(ctx *tcontext.TransferMetadata, g *GitHubAdapter, repo st
 	return &GitHubIterator{
 		client:     g.client,
 		sboms:      []*iterator.SBOM{},
-		binaryPath: g.BinaryPath,
+		binaryPath: g.config.BinaryPath,
 	}
 }
 

--- a/pkg/source/github/iterator.go
+++ b/pkg/source/github/iterator.go
@@ -28,25 +28,34 @@ import (
 
 // // GitHubIterator iterates over SBOMs fetched from GitHub (API, Release, Tool)
 type GitHubIterator struct {
-	client     *Client
-	sboms      []*iterator.SBOM // Stores all fetched SBOMs
-	position   int              // Tracks iteration position
-	binaryPath string
+	client   *Client
+	config   *GitHubConfig    // Added to avoid dependency on adapter
+	sboms    []*iterator.SBOM // Stores all fetched SBOMs
+	position int              // Tracks iteration position
 }
 
-// NewGitHubIterator initializes and returns a new GitHubIterator instance
-func NewGitHubIterator(ctx *tcontext.TransferMetadata, g *GitHubAdapter, repo string) *GitHubIterator {
-	logger.LogDebug(ctx.Context, "Initializing GitHub Iterator", "repo", g.config.URL, "method", g.config.Method, "repo", repo)
-
-	g.client.updateRepo(repo)
-
-	// Create and return the iterator instance without fetching SBOMs
+func NewGitHubIterator(ctx *tcontext.TransferMetadata, client *Client, config *GitHubConfig) *GitHubIterator {
+	logger.LogDebug(ctx.Context, "Initializing GitHub Iterator", "repo", config.URL, "method", config.Method)
 	return &GitHubIterator{
-		client:     g.client,
-		sboms:      []*iterator.SBOM{},
-		binaryPath: g.config.BinaryPath,
+		client: client,
+		config: config,
+		sboms:  []*iterator.SBOM{},
 	}
 }
+
+// // NewGitHubIterator initializes and returns a new GitHubIterator instance
+// func NewGitHubIterator(ctx *tcontext.TransferMetadata, g *GitHubAdapter, repo string) *GitHubIterator {
+// 	logger.LogDebug(ctx.Context, "Initializing GitHub Iterator", "repo", g.config.URL, "method", g.config.Method, "repo", repo)
+
+// 	g.client.updateRepo(repo)
+
+// 	// Create and return the iterator instance without fetching SBOMs
+// 	return &GitHubIterator{
+// 		client:     g.client,
+// 		sboms:      []*iterator.SBOM{},
+// 		binaryPath: g.config.BinaryPath,
+// 	}
+// }
 
 // FetchSBOMs fetches SBOMs for the given GitHubIterator instance
 func (it *GitHubIterator) HandleSBOMFetchingViaIterator(ctx *tcontext.TransferMetadata, method GitHubMethod) error {
@@ -142,7 +151,7 @@ func (it *GitHubIterator) fetchSBOMFromTool(ctx *tcontext.TransferMetadata) erro
 	}
 
 	// Generate SBOM and save in memory
-	sbomFile, err := GenerateSBOM(ctx, repoDir, it.binaryPath)
+	sbomFile, err := GenerateSBOM(ctx, repoDir, it.config.BinaryPath)
 	if err != nil {
 		return fmt.Errorf("failed to generate SBOM: %w", err)
 	}

--- a/pkg/source/github/tool.go
+++ b/pkg/source/github/tool.go
@@ -33,7 +33,13 @@ var SupportedTools = map[string]string{
 	"spdxgen": "https://github.com/spdx/spdx-sbom-generator.git",
 }
 
-func GenerateSBOM(ctx *tcontext.TransferMetadata, repoDir, binaryPath string) (string, error) {
+type SBOMGenerator interface {
+	Generate(ctx *tcontext.TransferMetadata, repoDir, binaryPath string) (string, error)
+}
+
+type SyftGenerator struct{}
+
+func (s *SyftGenerator) Generate(ctx *tcontext.TransferMetadata, repoDir, binaryPath string) (string, error) {
 	logger.LogDebug(ctx.Context, "Generating SBOM using Syft", "repo_dir", repoDir)
 
 	// Ensure Syft binary is executable

--- a/pkg/target/interlynk/adapter.go
+++ b/pkg/target/interlynk/adapter.go
@@ -29,17 +29,17 @@ import (
 
 // InterlynkAdapter manages SBOM uploads to the Interlynk service.
 type InterlynkAdapter struct {
-	client   *Client
+	client   InterlynkAPI
 	config   *InterlynkConfig
 	uploader SBOMUploader
 
 	Role types.AdapterRole
 }
 
-func NewInterlynkAdapter(config *InterlynkConfig, client *Client) *InterlynkAdapter {
+func NewInterlynkAdapter(config *InterlynkConfig, client InterlynkAPI) *InterlynkAdapter {
 	uploader, ok := uploaderFactory[string(config.Settings.ProcessingMode)]
 	if !ok {
-		uploader = uploaderFactory[string(types.UploadSequential)] // Default
+		uploader = uploaderFactory[string(types.UploadSequential)]
 	}
 	return &InterlynkAdapter{
 		config:   config,

--- a/pkg/target/interlynk/config.go
+++ b/pkg/target/interlynk/config.go
@@ -1,0 +1,35 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -------------------------------------------------------------------------
+
+package interlynk
+
+import "github.com/interlynk-io/sbommv/pkg/types"
+
+type InterlynkConfig struct {
+	BaseURL     string
+	ApiKey      string
+	ProjectName string
+	ProjectEnv  string
+	Role        types.AdapterRole
+	Settings    types.UploadSettings
+}
+
+func NewInterlynkConfig() *InterlynkConfig {
+	return &InterlynkConfig{
+		BaseURL:    "https://api.interlynk.io/lynkapi", // Default
+		ProjectEnv: "default",                          // Default
+		Settings:   types.UploadSettings{ProcessingMode: types.UploadSequential},
+	}
+}

--- a/pkg/target/interlynk/reporter.go
+++ b/pkg/target/interlynk/reporter.go
@@ -1,0 +1,99 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -------------------------------------------------------------------------
+
+// pkg/target/interlynk/reporter.go
+package interlynk
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/interlynk-io/sbommv/pkg/iterator"
+	"github.com/interlynk-io/sbommv/pkg/logger"
+	"github.com/interlynk-io/sbommv/pkg/sbom"
+)
+
+type InterlynkReporter struct {
+	baseURL string
+	apiKey  string
+}
+
+func NewInterlynkReporter(baseURL, apiKey string) *InterlynkReporter {
+	return &InterlynkReporter{
+		baseURL: baseURL,
+		apiKey:  apiKey,
+	}
+}
+
+func (r *InterlynkReporter) DryRun(ctx context.Context, iter iterator.SBOMIterator) error {
+	logger.LogDebug(ctx, "🔄 Dry-Run Mode: Simulating Upload to Interlynk...")
+
+	// Step 1: Validate Interlynk Connection
+	if err := ValidateInterlynkConnection(r.baseURL, r.apiKey); err != nil {
+		return fmt.Errorf("interlynk validation failed: %w", err)
+	}
+
+	// Step 2: Initialize SBOM Processor
+	processor := sbom.NewSBOMProcessor("", false)
+
+	// Step 3: Organize SBOMs into Projects
+	projectSBOMs := make(map[string][]sbom.SBOMDocument)
+	totalSBOMs := 0
+	uniqueFormats := make(map[string]struct{})
+
+	for {
+		sbom, err := iter.Next(ctx)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			logger.LogError(ctx, err, "Error retrieving SBOM from iterator")
+			return err // Propagate error
+		}
+
+		processor.Update(sbom.Data, sbom.Namespace, sbom.Path)
+		doc, err := processor.ProcessSBOMs()
+		if err != nil {
+			logger.LogError(ctx, err, "Failed to process SBOM")
+			return err
+		}
+
+		projectKey := fmt.Sprintf("%s", sbom.Namespace)
+		projectSBOMs[projectKey] = append(projectSBOMs[projectKey], doc)
+		totalSBOMs++
+		uniqueFormats[string(doc.Format)] = struct{}{}
+	}
+
+	// Step 4: Print Dry-Run Summary
+	fmt.Println("")
+	fmt.Printf("📦 Interlynk API Endpoint: %s\n", r.baseURL)
+	fmt.Printf("📂 Project Groups Total: %d\n", len(projectSBOMs))
+	fmt.Printf("📊 Total SBOMs to be Uploaded: %d\n", totalSBOMs)
+	fmt.Printf("📦 INTERLYNK_SECURITY_TOKEN is valid\n")
+	fmt.Printf("📦 Unique Formats: %s\n", formatSetToString(uniqueFormats))
+	fmt.Println()
+
+	for project, sboms := range projectSBOMs {
+		fmt.Printf("📌 **Project: %s** → %d SBOMs\n", project, len(sboms))
+		for _, doc := range sboms {
+			fmt.Printf("   - 📁  | Format: %s | SpecVersion: %s | Size: %d KB | Filename: %s\n",
+				doc.Format, doc.SpecVersion, len(doc.Content)/1024, doc.Filename)
+		}
+	}
+
+	fmt.Println("\n✅ **Dry-run completed**. No data was uploaded to Interlynk.")
+	return nil
+}

--- a/pkg/target/interlynk/uploader.go
+++ b/pkg/target/interlynk/uploader.go
@@ -1,0 +1,85 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -------------------------------------------------------------------------
+
+package interlynk
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/interlynk-io/sbommv/pkg/iterator"
+	"github.com/interlynk-io/sbommv/pkg/logger"
+	"github.com/interlynk-io/sbommv/pkg/tcontext"
+	"github.com/interlynk-io/sbommv/pkg/types"
+)
+
+type SBOMUploader interface {
+	Upload(ctx *tcontext.TransferMetadata, client *Client, iter iterator.SBOMIterator) error
+}
+
+type SequentialUploader struct{}
+
+var uploaderFactory = map[string]SBOMUploader{
+	string(types.UploadSequential): &SequentialUploader{},
+	// Add parallel and batch uploaders later
+}
+
+func (u *SequentialUploader) Upload(ctx *tcontext.TransferMetadata, client *Client, iter iterator.SBOMIterator) error {
+	logger.LogDebug(ctx.Context, "Uploading SBOMs sequentially")
+	errorCount := 0
+	maxRetries := 5
+
+	for {
+		sbom, err := iter.Next(ctx.Context)
+		if err == io.EOF {
+			logger.LogDebug(ctx.Context, "All SBOMs uploaded successfully")
+			break
+		}
+		if err != nil {
+			logger.LogInfo(ctx.Context, "Failed to retrieve SBOM", "error", err)
+			errorCount++
+			if errorCount >= maxRetries {
+				return fmt.Errorf("exceeded max retries (%d): %w", maxRetries, err)
+			}
+			continue
+		}
+		errorCount = 0
+		projectID, err := client.FindOrCreateProjectGroup(ctx, sbom.Namespace)
+		if err != nil {
+			logger.LogInfo(ctx.Context, "Failed to get project", "repo", sbom.Namespace, "error", err)
+			continue
+		}
+
+		if err := client.UploadSBOM(ctx, projectID, sbom.Data); err != nil {
+			logger.LogInfo(ctx.Context, "Failed to upload SBOM", "repo", sbom.Namespace, "error", err)
+		} else {
+			logger.LogDebug(ctx.Context, "Successfully uploaded SBOM", "repo", sbom.Namespace)
+		}
+	}
+	return nil
+}
+
+// TODO:
+
+/*
+type ParallelUploader struct{}
+
+func (u *ParallelUploader) Upload(ctx *tcontext.TransferMetadata, client *Client, iter iterator.SBOMIterator) error {
+}
+
+type BatchUploader struct{}
+func (u *BatchUploader) Upload(ctx *tcontext.TransferMetadata, client *Client, iter iterator.SBOMIterator) error {
+}
+*/

--- a/pkg/target/interlynk/uploader.go
+++ b/pkg/target/interlynk/uploader.go
@@ -26,7 +26,7 @@ import (
 )
 
 type SBOMUploader interface {
-	Upload(ctx *tcontext.TransferMetadata, client *Client, iter iterator.SBOMIterator) error
+	Upload(ctx *tcontext.TransferMetadata, client InterlynkAPI, iter iterator.SBOMIterator) error
 }
 
 type SequentialUploader struct{}
@@ -36,7 +36,7 @@ var uploaderFactory = map[string]SBOMUploader{
 	// Add parallel and batch uploaders later
 }
 
-func (u *SequentialUploader) Upload(ctx *tcontext.TransferMetadata, client *Client, iter iterator.SBOMIterator) error {
+func (u *SequentialUploader) Upload(ctx *tcontext.TransferMetadata, client InterlynkAPI, iter iterator.SBOMIterator) error {
 	logger.LogDebug(ctx.Context, "Uploading SBOMs sequentially")
 	errorCount := 0
 	maxRetries := 5


### PR DESCRIPTION

### Overview
This refractor Folder input (`pkg/source/folder`) and output (`pkg/target/folder`) adapters to align with **Single Responsibility Principle(SRP)** and **Open/Closed Principle (OCP)** from SOLID principles. LSP/ISP and DIP are deferred for later.

### Why SOLID?
### Single Responsibility Principle (SRP) for Folder Input Adapter and Output Adapter

#### a. Split `GithubAdapter` Configuration from Logic (SRP)
- **Solution**: 
  - Separate the GitHubAdapter’s configuration state from its behavior to follow the Single Responsibility Principle (SRP).
- **Why**:  
  - The current `GithubAdapter` struct mixes configuration (e.g., `Path`, `URL`, `Branch`) with logic (e.g., fetching SBOMs) and violate SRP principle. 
- **Changes**:
  - Create a `GithubConfig` struct to hold all configuration data.
  - Update `GithubAdapter` to use this config struct instead of individual fields.
    
 #### b. Extract Dry-Run Logic (SRP)
 - **Solution**: 
   - Move `DryRun` logic into a separate SBOMReporter struct to keep GithubAdapter focused on fetching.
- **Why**: 
  - The current `DryRun` mixes SBOM processing with output formatting, violating SRP.
- **Changes**:
  - Create a `SBOMReporter` struct in a new `reporter` file in the same pkg.

### Open/Closed Principle (OCP) for Github Input Adapter
#### Introduce Strategy Pattern for Fetch Methods (OCP)

- **Solution**: 
  - Refactor the fetching logic to follow the Open/Closed Principle, making it extensible without modifying existing code when adding new fetch methods.

- **Why**: 
  - Currently, adding a new fetch method (e.g., "fetch using parallel or batch") requires modifying GithubAdapter FetchSBOMs and GithubIterator's  with new switch cases. This violates OCP because the code isn’t closed to modification.

- **Changes**:
  - Define an SBOMFetcher interface for different fetch strategies.
  - Implement concrete fetchers (SequentialFetcher, ParallelFetcher).

### Open/Closed Principle (OCP) for Interlynk Output Adapter
- **Solution**: 
  - Introduce a strategy pattern for upload modes to make the adapter extensible without modifying existing code.

- **Why**: 
  - The current `UploadSBOMs` uses a switch with only `UploadSequential` implemented, requiring changes to add parallel or batch modes.

- **Changes**:
  - Define an `SBOMUploader` interface.
  - Implement concrete uploaders (SequentialUploader for now).
  - Update InterlynkAdapter to use the strategy.

