### PR TITLE
add docs for folder adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/interlynk-io/sbommv)](https://goreportcard.com/report/github.com/interlynk-io/sbommv)
 ![GitHub all releases](https://img.shields.io/github/downloads/interlynk-io/sbommv/total)
 
-`sbommv` is your primary tool to transfer SBOM's between different systems.It is designed to allow transfer sboms across systems. The tool supports input, translation, enrichment & output adapters which allow it to be extensible in the future. Input adapters are responsbile to interface with services and provide various methods to extract sboms. The output adapters handles all the complexity related to uploading sboms. 
+`sbommv` is your primary tool to transfer SBOM's between different systems.It is designed to allow transfer sboms across systems. The tool supports input, translation, enrichment & output adapters which allow it to be extensible in the future. Input adapters are responsbile to interface with services and provide various methods to extract sboms. The output adapters handles all the complexity related to uploading sboms.
 
 ```console
 brew tap interlynk-io/interlynk
@@ -13,10 +13,10 @@ brew install sbommv
 
 Other [installation options](#installation).
 
-# SBOM Platform - Free Tier
+# SBOM Platform - [Interlynk](https://app.interlynk.io/)
 
-Our SBOM Automation Platform has a new free tier that provides a comprehensive solution to manage SBOMs (Software Bill of Materials) effortlessly. From centralized SBOM storage, built-in SBOM editor, continuous vulnerability mapping and assessment, and support for organizational policies, all while ensuring compliance and enhancing software supply chain security using integrated SBOM quality scores. The free tier is ideal for small teams. [Sign up](https://app.interlynk.io/)
-
+Our SBOM Automation Platform has a new free tier that provides a comprehensive solution to manage SBOMs (Software Bill of Materials) effortlessly. From centralized SBOM storage, built-in SBOM editor, continuous vulnerability mapping and assessment, and support for organizational policies, all while ensuring compliance and enhancing software supply chain security using integrated SBOM quality scores. The free tier is ideal for small teams.
+[Try now](https://app.interlynk.io/)
 
 ## Why sbommv
 
@@ -24,37 +24,49 @@ Our SBOM Automation Platform has a new free tier that provides a comprehensive s
 
 A Software Bill of Materials (SBOM) plays a crucial role in software supply chain security, compliance, and vulnerability management. However, organizations face a key challenge: **How do you efficiently move SBOMs between different systems?**.
 
-There are two major categories of systems dealing with SBOMs: SBOM Sources (Input Systems) and SBOM Consumers (Output Systems). Manually fetching SBOMs from input systems and uploading them to output systems is: Time-consuming, Error-prone and Difficult to scale.
+There are two major categories of systems dealing with SBOMs: **SBOM Sources** (Input/Source Systems) and **SBOM Consumers** (Output/Target Systems). Manually fetching SBOMs from input systems and uploading them to output systems is: Time-consuming, Error-prone and Difficult to scale.
 
 ### The Solution: Automating SBOM Transfers(sbommv)
 
-sbommv is designed to move SBOMs between systems effortlessly. It provides: **Input Adapters**(Fetch SBOMs from different sources) and **Output Adapters**(Upload SBOMs to analysis and security platforms). Currently sbommv support **github** as a input adapter and **interlynk** as aoutput adapter.
+sbommv is designed to move SBOMs between systems effortlessly. It provides: **Input Adapters**(Fetch SBOMs from different sources) and **Output Adapters**(Upload SBOMs to analysis and security platforms). Currently sbommv support following input and output adapters:
+
+- Input Adapters --> github, folder
+- Output Adapters --> interlynk, folder
 
 ## How sbommv Works ?
 
-- Extract SBOMs from Input Systems (GitHub, package registries, etc.)
+- Extract SBOMs from Input Systems (GitHub, local folders, package registries, etc.)
 - Transform or Enrich SBOMs (Future capabilities for format conversion, enrichment)
-- Send SBOMs to Output Systems (Security tools, SBOM repositories, compliance platforms)
+- Send SBOMs to Output Systems(Interlynk, Dependency-Track(coming soon), folders, Security tools, SBOM repositories, compliance platforms). Whereas the folder output system is just for testing purpose, to see the SBOMs you fetched from Input Adapters.
 
-**Examples**
+### Examples
 
-1. **Generate & Transfer SBOM's for all repositories in Github org of `interlynk-io` to Interlynk SBOM's platform**:
-   Generate & Transfer SBOM's from all repositories in the interlynk-io github organization using github apis, and transfer them to interlynk. If interlynk platform does not contain projects it will create them.
+#### 1. Pre-requistic:
 
-   ```bash
-   $ export GITHUB_TOKEN=ghp_klgJBxKukyaoWA******
-   $ export INTERLYNK_SECURITY_TOKEN=lynk_api******
-   $ sbommv transfer --input-adapter=github --in-github-url="https://github.com/interlynk-io" --output-adapter=interlynk --out-interlynk-url="http://localhost:3000/lynkapi"
-   ```
+- Generate **INTERLYNK_SECURITY_TOKEN** with the help of this [resource](https://github.com/interlynk-io/sbommv/blob/main/docs/getting_started.md#2-configuring-interlynk-authentication).
+- Until and unless you get an *Rate Limitor error*, github API will work for you. But as you get, generate  GITHUB_TOKEN from [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic).
 
-2. **DRY RUN: Transfer SBOM from the latest version of sbomqs to interlynk platform**:
-  This will look for the latest release of the repository and check if SBOMs are generated, in dry-run mode, it will just iterate the sboms found, and check if login to the output adapter works.
-
-   ```bash
+```bash
+   # export the tokens
    export GITHUB_TOKEN=ghp_klgJBxKukyaoWA******
    export INTERLYNK_SECURITY_TOKEN=lynk_api******
+```
+
+#### 2. Generate & Transfer SBOM's for all repositories in Github org of `interlynk-io` to Interlynk SBOM's platform
+
+Generate & Transfer SBOM's from all repositories in the `interlynk-io` github organization using github apis, and transfer them to interlynk. If interlynk platform does not contain projects it will create them.
+
+```bash
+   sbommv transfer --input-adapter=github --in-github-url="https://github.com/interlynk-io" --output-adapter=interlynk --out-interlynk-url="http://localhost:3000/lynkapi"
+```
+
+#### 3. DRY RUN: Transfer SBOM from the latest version of sbomqs to interlynk platform:
+
+This will look for the latest release of the repository and check if SBOMs are generated, in dry-run mode, it will just iterate the sboms found, and check if login to the output adapter works.
+
+```bash
    sbommv transfer --input-adapter=github  --in-github-url=https://github.com/interlynk-io/sbomqs --in-github-method="release" --output-adapter=interlynk  --out-interlynk-url=https://api.interlynk.io/lynkapi --dry-run
-   ```
+```
 
 ## What's next 🚀 ??
 
@@ -78,12 +90,16 @@ sbommv is designed to move SBOMs between systems effortlessly. It provides: **In
 * Coming Soon
 ```
 
-## Adapters 
+## Adapters
 
+At its core, sbommv acts as a bridge, seamlessly connecting SBOM source systems (e.g., GitHub, AWS, folders, local files) with SBOM consumer systems (e.g., Interlynk, Dependency-Track, folder, security tools) — eliminating manual work.
+To achieve this, sbommv follows an **adapter-based architecture**, where different systems are abstracted as input and output adapters
 
 ### Input Adapters
 
-#### GitHub
+Responsible for fetching SBOMs from various sources.
+
+#### 1. GitHub
 
 The **GitHub adapter** allows you to extract/download SBOMs from GitHub. The adapter provides the following methods of extracting SBOMs:
 
@@ -96,18 +112,14 @@ The **GitHub adapter** allows you to extract/download SBOMs from GitHub. The ada
 - **Tool**:  
   This method clones the repository and runs your tool of choice to generate the SBOM.
 
----
+- **Github Adapter specific CLI parameters**
 
-**Command-line Parameters Supported by the Adapter**
+  - `--in-github-url`: Takes the repository or owner URL for GitHub.  
+  - `--in-github-include-repos`: Specifies repositories from which SBOMs should be extracted.  
+  - `--in-github-exclude-repos`: Specifies repositories to exclude from SBOM extraction.  
+  - `--in-github-method`: Specifies the method of extraction (`release`, `api`, or `tool`).  
 
-- `--in-github-url`: Takes the repository or owner URL for GitHub.  
-- `--in-github-include-repos`: Specifies repositories from which SBOMs should be extracted.  
-- `--in-github-exclude-repos`: Specifies repositories to exclude from SBOM extraction.  
-- `--in-github-method`: Specifies the method of extraction (`release`, `api`, or `tool`).  
-
----
-
-**Usage Examples**
+- **Github Adapter Usage Examples**
 
 1. **For the latest release version of `sbomqs` using the release method**:  
    This will look for the latest release of the repository and check if SBOMs are generated.
@@ -135,36 +147,69 @@ The **GitHub adapter** allows you to extract/download SBOMs from GitHub. The ada
 
    ```bash
    --in-github-url=https://github.com/interlynk-io \
-   --in-github-exclude-repos=sbomqs 
+   --in-github-exclude-repos=sbomqs
    ```
 
-4. **All repositories from `interlynk-io` using the API method**:
+5. **All repositories from `interlynk-io` using the API method**:
 
    ```bash
    --in-github-url=https://github.com/interlynk-io 
    ```
 
----
+#### 2. Folder Intput Adapter
 
+The **Folder Adapter** allows you to extract/fetch SBOMs from local Folder. The adapter job is to fetch SBOMs (Software Bills of Materials) from a local filesystem directory.  It’s designed to scan a specified folder, optionally including subdirectories. Unlike the GitHub adapter, which interacts with a remote service, the Folder adapter works with local files.
 
-### Output Adapters 
+- **Folder Adapter specific CLI parameters**
 
-#### Interlynk
+  - `--in-folder-path`: Takes the folder path.  
+  - `--in-folder-recursive`: Specifies whether to scan within sub-directories. By default(`false`), it doesn't scn within sub-directories.
+  - `in-folder-processing-mode`: Mode of fetching SBOMs, in sequential/parallel. By default, it's `sequential`.
+
+- **Folder Adapter Usage Examples**
+
+1. **To fetch SBOM from root folder `sboms_ws` in a sequential manner**.
+   This will look for the latest release of the repository and check if SBOMs are generated.
+
+   ```bash
+   --in-folder-path=sboms_ws
+   --in-folder-recursive=false
+   --in-folder-processing-mode="sequential"
+   ```
+
+2. **To fetch SBOM from root folder `sboms_ws` as well as it's sub-directories in a sequential mode**.
+   This will look for the latest release of the repository and check if SBOMs are generated.
+
+   ```bash
+   --in-folder-path=sboms_ws
+   --in-folder-recursive=true
+   --in-folder-processing-mode="sequential"
+   ```
+
+3. **To fetch SBOM from root folder `sboms_ws` as well as it's sub-directories in a parallel mode**.
+   This will look for the latest release of the repository and check if SBOMs are generated.
+
+   ```bash
+   --in-folder-path=sboms_ws
+   --in-folder-recursive=true
+   --in-folder-processing-mode="parallel"
+
+### Output Adapters
+
+Responsible for uploading SBOMs to SBOM platforms, Security Platforms, etc.
+
+#### 1. Interlynk
 
 The **Interlynk adapter** allows you to upload SBOMs to Interlynk Enterprise Platform. If no repository name is specified, it will auto-create projects & the env on the platform.
-To access this platform `INTERLYNK_SECURITY_TOKEN`, will be required. 
+To access this platform `INTERLYNK_SECURITY_TOKEN`, will be required.
 
----
+- **Interlynk Adapter CLI Parameters**
 
-**Command-line Parameters Supported by the Adapter**
+  - `--out-interlynk-url` [Optional]: URL for the interlynk service. Defaults to `https://api.interlynk.io/lynkapi`  
+  - `--out-interlynk-project-name` [Optional]:  Name of the project to upload the SBOM to, this is optional, if not-provided then it auto-creates it.
+  - --out-interlynk-project-env` [Optional]: Defaults to the "default" env.
 
-- `--out-interlynk-url` [Optional]: URL for the interlynk service. Defaults to `https://api.interlynk.io/lynkapi`  
-- `--out-interlynk-project-name` [Optional]:  Name of the project to upload the SBOM to, this is optional, if not-provided then it auto-creates it. 
-- --out-interlynk-project-env` [Optional]: Defaults to the "default" env.   
-
----
-
-**Usage Examples**
+- **Usage Examples**
 
 1. **Upload SBOMs to a particular project**:  
 
@@ -178,6 +223,33 @@ To access this platform `INTERLYNK_SECURITY_TOKEN`, will be required.
    --out-interlynk-project-name=abc
    --out-interlynk-project-env=production
    ```
+
+#### 2. Folder Output Adapter
+
+The **Folder Adapter** allows you to save SBOMs to local Folder. The adapter job is to save SBOMs (Software Bills of Materials) to a local filesystem directory.  It’s designed to save a specified folder. Unlike the Interlynk adapter, which interacts with a remote service, the Folder adapter works with local folders.
+
+- **Folder Adapter specific CLI parameters**
+
+  - `--out-folder-path`: folder path to save SBOMs.  
+  - `--in-folder-recursive`: Specifies whether to scan within sub-directories. By default(`false`), it doesn't scn within sub-directories.
+  - `--out-folder-processing-mode`: Mode of saving SBOMs i.e in sequential/parallel. By default, it's `sequential`.
+
+- **Folder Adapter Usage Examples**
+
+1. **To save SBOM to root folder `temp` in a sequential manner**.
+   This will look for the latest release of the repository and check if SBOMs are generated.
+
+   ```bash
+   --out-folder-path=temp
+   --out-folder-processing-mode="sequential"
+   ```
+
+2. **To save SBOMs to root folder `temp` in a parallel/concurrent mode**.
+   This will look for the latest release of the repository and check if SBOMs are generated.
+
+   ```bash
+   --out-folder-path=temp
+   --out-folder-processing-mode="parallel"
 
 # Installation
 
@@ -220,6 +292,7 @@ We look forward to your contributions, below are a few guidelines on how to subm
 - Create a new pull-request
 
 # Other Open Source Software tools for SBOMs
+
 - [SBOM Quality Score](https://github.com/interlynk-io/sbomqs) - Quality & Compliance tool
 - [SBOM Assembler](https://github.com/interlynk-io/sbomasm) - A tool to compose a single SBOM by combining other SBOMs or parts of them
 - [SBOM Quality Score](https://github.com/interlynk-io/sbomqs) - A tool for evaluating the quality and completeness of SBOMs
@@ -241,4 +314,3 @@ We appreciate all feedback. The best ways to get in touch with us:
 If you like this project, please support us by starring it.
 
 [![Stargazers](https://starchart.cc/interlynk-io/sbommv.svg)](https://starchart.cc/interlynk-io/sbommv)
-

--- a/cmd/transfer.go
+++ b/cmd/transfer.go
@@ -44,6 +44,15 @@ sbommv transfer -D --input-adapter=github --in-github-url="https://github.com/in
 # Fetch SBOMs using the GitHub adapter via the api method for the latest repository version
 sbommv transfer --input-adapter=github --in-github-url="https://github.com/sigstore/cosign" --in-github-method=api  \
 --output-adapter=interlynk --out-interlynk-url="http://localhost:3000/lynkapi"
+
+# Fetch SBOMs from github repo and save it to a folder "temp"
+sbommv transfer --input-adapter=github --in-github-url="https://github.com/sigstore/" --in-github-include-repos=cosign,fulcio,rekor \
+--in-github-method="release" --output-adapter=folder --out-folder-path="temp"
+
+# Fetch SBOMs from folder "temp" and upload/push it to a Interlynk
+sbommv transfer --input-adapter=folder --in-folder-path="temp"  --in-folder-recursive=true  --output-adapter=interlynk \
+--out-interlynk-url="http://localhost:3000/lynkapi"
+
 	`,
 	Args: cobra.NoArgs,
 	RunE: transferSBOM,

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -25,6 +25,7 @@ Once SBOMs are fetched, they are uploaded to Interlynk. To use Interlynk, you ne
 1. [Create an Interlynk account](https://app.interlynk.io/auth).
 2. Generate an INTERLYNK_SECURITY_TOKEN from [here](https://app.interlynk.io/vendor/settings?tab=security%20tokens).
 3. Export the token before running `sbommv`
+
     ```bash
     export INTERLYNK_SECURITY_TOKEN="lynk_test_EV2DxRfCfn4wdM8FVaiGkb6ny3KgSJ7JE5zT"
     ```
@@ -122,9 +123,9 @@ sbommv transfer --input-adapter=github --in-github-url="https://github.com/sigst
 
 - Useful for previewing the SBOMs to be uploaded, project to be created on Interlynk.
 
-## 2. Advanced Transfer(Organization Repos): GitHub → Interlynk
+## 3. Advanced Transfer(Organization Repos): GitHub → Interlynk
 
-### 2.1 Github Release Method
+### 3.1 Github Release Method
 
 #### Fetch SBOMs from a GitHub Organization, Including Only Specific Repos and then upload to interlynk
 
@@ -170,7 +171,6 @@ sbommv transfer --input-adapter=github --in-github-url="https://github.com/sigst
   - Uploads them as separate projects in Interlynk.
   - `cosign`, `rekor` SBOMs will be uploaded to `sigstore/cosign` and `sigstore/reko` respectively.
 
-
 #### Fetch SBOMs using API method from a GitHub Organization by excluding Specific Repos and then upload to interlynk
 
 ```bash
@@ -209,6 +209,31 @@ sbommv transfer --input-adapter=github --in-github-url="https://github.com/sigst
 - **What this does**:
   - Fetches SBOMs from all repositories in `sigstore` except `docs`.
   - Uploads them as separate projects in Interlynk.
+
+## 4. GitHub  → Folder
+
+### Fetch SBOMs from github repo and save it to a folder
+
+```bash
+ sbommv transfer --input-adapter=github --in-github-url="https://github.com/sigstore/" --in-github-include-repos=cosign,fulcio,rekor --in-github-method="release" --output-adapter=folder --out-folder-path="temp"
+```
+
+- **What this does**:
+  - Fetches SBOMs from `sigstore` organization for repositories in `cosign`, `fulcio`, and `rekor`.
+  - Save these SBOMs to a folder `temp`.
+  - Under `temp`, seperate sub-dir with name `cosign`, `fulcio` and `rekor` will be created and respective repo SBOMs will be stored there.
+
+## 4. Folder → Interlynk
+
+### Fetch SBOMs from folder "temp" and upload/push it to a Interlynk
+
+```bash
+sbommv transfer --input-adapter=folder --in-folder-path="temp"  --in-folder-recursive=true  --output-adapter=interlynk --out-interlynk-url="http://localhost:3000/lynkapi"
+```
+
+- **What this does**:
+  - Fetches/Scan SBOMs from `temp` directory for all sub-directories such as `cosign`, `fulcio`, and `rekor`.
+  - Upload these SBOMs to a Interlynk with a project ID `cosign`, `fulcio`, and `rekor`.
 
 ## Some More Examples
 

--- a/docs/flag_usage.md
+++ b/docs/flag_usage.md
@@ -11,7 +11,7 @@ These flags apply to **all commands**, regardless of input or output adapters.
 - `--dry-run` : **Simulates the transfer process** without actually uploading SBOMs. This allows users to preview the results before making real changes.
 - `-h, --help` : Displays the help menu for the `sbommv transfer` command.
 
-## 🔹 Input Adapter: GitHub Flags
+## 1. Input Adapter GitHub Flags
 
 The **GitHub adapter** allows fetching SBOMs from repositories or organizations. The following flags control how SBOMs are retrieved.
 
@@ -30,7 +30,17 @@ The **GitHub adapter** allows fetching SBOMs from repositories or organizations.
   - Example: `--in-github-url=https://github.com/sigstore`
 - **For a specific branch** → Use `--in-github-branch="<branch_name>"` (only with the tool method)  
 
-## 🔹 Output Adapter: Interlynk Flags
+## 2. Input Adapter Folder Flags
+
+The **Folder adapter** allows fetching/scanning SBOMs from directories and sub-directories. The following flags control how SBOMs are retrieved.
+
+- `--input-adapter=folder`: **Specifies Folder as the input system** to fetch SBOMs. **(Required)** 
+- `--in-folder-path=<path>`: **Folder path** from which to scan/fetch SBOMs.
+- `--in-folder-recursive=true`: Specifies to scan from all sub-directories under provided path.
+- `--in-folder-processing-mode="parallel`: **SBOM fetching mode**, fetch or scan sboms cuncurrently or parralelly, which is quite faster than sequential mode.
+
+
+## 1. Output Adapter: Interlynk Flags
 
 The **Interlynk adapter** is used for uploading SBOMs to **Interlynk’s SBOM Management Platform**.
 
@@ -45,11 +55,17 @@ The **Interlynk adapter** is used for uploading SBOMs to **Interlynk’s SBOM Ma
 - **Uploading to a custom environment** → Use `--out-interlynk-project-env="development"`
 - **NOTE**: For entire organization, no need to provide specific project, it will be automatically created as per requirements.
 
-## 📌 Summary
+## 2. Ouput Adapter Folder Flags
 
-✅ **GitHub Flags** → Control how SBOMs are fetched  
-✅ **Interlynk Flags** → Control how SBOMs are uploaded  
-✅ **Test with `--dry-run`** before uploading  
+The **Folder adapter** allows fetching/scanning SBOMs from directories and sub-directories. The following flags control how SBOMs are retrieved.
+
+- `--output-adapter=folder`: **Specifies Folder as the output system** to save SBOMs. **(Required)**
+- `--out-folder-path=<path>`: **Folder path** to which to save or download the SBOMs.
+- `--out-folder-processing-mode="parallel`: **SBOM saving mode**, save sboms cuncurrently or parralelly, which is quite faster than sequential mode.
+
+## 📌 NOTE
+
+✅ To see the display of how many SBOMs are fetched or how many SBOMs to be uploaded, use `--dry-run`. It provides you rough idea about what being fetched and what would be uploaded.  
 
 📌 **Looking for command examples?** → [Check out the Example Guide](https://github.com/interlynk-io/sbommv/blob/main/docs/examples.md)  
 📌 **Want to get started quickly?** → [Read Getting Started with sbommv]([./docs/GettingStarted.md](https://github.com/interlynk-io/sbommv/blob/main/docs/getting_started.md))  


### PR DESCRIPTION
This PR adds the following changes:
- Update the README to add folder as input and output adapter, along with flag and command usage
- Update example.md to add examples for folder adapter
- added examples in sbommv transfer help command.