### PR TITLE
Enforce Adapter-Specific Flag Prefix Validation

### DIFF
--- a/pkg/source/folder/adapter.go
+++ b/pkg/source/folder/adapter.go
@@ -22,6 +22,7 @@ import (
 	"github.com/interlynk-io/sbommv/pkg/logger"
 	"github.com/interlynk-io/sbommv/pkg/tcontext"
 	"github.com/interlynk-io/sbommv/pkg/types"
+	"github.com/interlynk-io/sbommv/pkg/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -60,6 +61,9 @@ func (f *FolderAdapter) ParseAndValidateParams(cmd *cobra.Command) error {
 		return fmt.Errorf("The adapter is neither an input type nor an output type")
 
 	}
+
+	// validate flags for respective adapters
+	utils.FlagValidation(cmd, types.FolderAdapterType, types.InputAdapterFlagPrefix)
 
 	// Extract Folder Path
 	folderPath, _ := cmd.Flags().GetString(pathFlag)

--- a/pkg/source/github/adapter.go
+++ b/pkg/source/github/adapter.go
@@ -98,6 +98,8 @@ func (g *GitHubAdapter) ParseAndValidateParams(cmd *cobra.Command) error {
 	default:
 		return fmt.Errorf("The adapter is neither an input type nor an output type")
 	}
+	// validate flags for respective adapters
+	utils.FlagValidation(cmd, types.GithubAdapterType, types.InputAdapterFlagPrefix)
 
 	// Extract GitHub URL
 	githubURL, _ := cmd.Flags().GetString(urlFlag)

--- a/pkg/target/folder/adapter.go
+++ b/pkg/target/folder/adapter.go
@@ -22,6 +22,7 @@ import (
 	"github.com/interlynk-io/sbommv/pkg/logger"
 	"github.com/interlynk-io/sbommv/pkg/tcontext"
 	"github.com/interlynk-io/sbommv/pkg/types"
+	"github.com/interlynk-io/sbommv/pkg/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -57,6 +58,9 @@ func (f *FolderAdapter) ParseAndValidateParams(cmd *cobra.Command) error {
 		return fmt.Errorf("The adapter is neither an input type nor an output type")
 
 	}
+
+	// validate flags for respective adapters
+	utils.FlagValidation(cmd, types.FolderAdapterType, types.OutputAdapterFlagPrefix)
 
 	// Extract Folder Path
 	folderPath, _ := cmd.Flags().GetString(pathFlag)

--- a/pkg/target/interlynk/adapter.go
+++ b/pkg/target/interlynk/adapter.go
@@ -72,6 +72,9 @@ func (i *InterlynkAdapter) ParseAndValidateParams(cmd *cobra.Command) error {
 		return fmt.Errorf("The adapter is neither an input type nor an output type")
 	}
 
+	// validate flags for respective adapters
+	utils.FlagValidation(cmd, types.InterlynkAdapterType, types.OutputAdapterFlagPrefix)
+
 	// Get flags
 	url, _ := cmd.Flags().GetString(urlFlag)
 	projectName, _ := cmd.Flags().GetString(projectNameFlag)

--- a/pkg/types/adapter_types.go
+++ b/pkg/types/adapter_types.go
@@ -49,3 +49,10 @@ const (
 type UploadSettings struct {
 	ProcessingMode UploadMode // "sequential", "parallel", or "batch"
 }
+
+type FlagPrefix string
+
+const (
+	InputAdapterFlagPrefix  FlagPrefix = "in"
+	OutputAdapterFlagPrefix FlagPrefix = "out"
+)

--- a/pkg/utils/validation.go
+++ b/pkg/utils/validation.go
@@ -1,0 +1,43 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/interlynk-io/sbommv/pkg/logger"
+	"github.com/interlynk-io/sbommv/pkg/types"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// FlagValidation validates that each adapter should contain flag of respective adapters only
+func FlagValidation(cmd *cobra.Command, adapter types.AdapterType, adapterPrefix types.FlagPrefix) {
+	cmd.Flags().Visit(func(f *pflag.Flag) {
+		// out-
+		flagPrefix := fmt.Sprintf("%s"+"-", string(adapterPrefix))
+
+		// out-folder-
+		flagType := fmt.Sprintf("%s%s-", flagPrefix, string(adapter))
+
+		// f.Name: out-interlynk-url
+
+		if strings.HasPrefix(f.Name, flagPrefix) && !strings.HasPrefix(f.Name, flagType) {
+			logger.LogError(cmd.Context(), fmt.Errorf("invalid flag for input adapter 'github': %s", f.Name), "flag", f.Name)
+			panic(fmt.Sprintf("Error: flag --%s is invalid for input adapter %s", f.Name, string(adapter)))
+		}
+	})
+}


### PR DESCRIPTION
closes #63 

This PR add the following changes:
- This PR ensures that input adapters only accept `--in-<adapter>-` flags and output adapters only accept `--out-<adapter>-` flags, rejecting mismatched or opposite-role flags with clear errors. For example, `--in-folder-recursive` with `--input-adapter=github` now fails.

```bash
$ go run main.go transfer --input-adapter=github \
                        --in-github-url="https://github.com/sigstore/cosign" \
                        --in-github-method="release" \
                        --in-folder-recursive=true \
                        --output-adapter=folder \
                        --out-folder-path="temp" \
--out-interlynk-url="http://localhost:3000/lynkapi"
```

- Similarly,  For example, `--out-interlynk-url` with `--output-adapter=folder` now fails.

```
$  go run main.go transfer --input-adapter=github \
                        --in-github-url="https://github.com/sigstore/cosign" \
                        --in-github-method="release" \
                        --output-adapter=folder \
                        --out-folder-path="temp" \
--out-interlynk-url="http://localhost:3000/lynkapi"
```