### PR TITLE
add description, project as active and tags

### DIFF
--- a/pkg/engine/transfer.go
+++ b/pkg/engine/transfer.go
@@ -41,10 +41,14 @@ func TransferRun(ctx context.Context, cmd *cobra.Command, config types.Config) e
 	var inputAdapterInstance, outputAdapterInstance adapter.Adapter
 	var err error
 
-	adapters, err := adapter.NewAdapter(transferCtx, config)
+	adapters, iAdp, oAdp, err := adapter.NewAdapter(transferCtx, config)
 	if err != nil {
 		return fmt.Errorf("failed to initialize adapters: %v", err)
 	}
+
+	// store source adapter type and destination adapter using ctx for later use
+	transferCtx.WithValue("source", iAdp)
+	transferCtx.WithValue("destination", oAdp)
 
 	// Extract input and output adapters using predefined roles
 	inputAdapterInstance = adapters[types.InputAdapterRole]

--- a/pkg/target/dependencytrack/client.go
+++ b/pkg/target/dependencytrack/client.go
@@ -115,8 +115,13 @@ func (c *DependencyTrackClient) CreateProject(ctx *tcontext.TransferMetadata, pr
 	logger.LogDebug(ctx.Context, "Initializing Project Creation", "project", projectName, "version", projectVersion)
 
 	project := dtrack.Project{
-		Name:    projectName,
-		Version: projectVersion,
+		Name:        projectName,
+		Version:     projectVersion,
+		Active:      true,
+		Description: "Created & uploaded by sbommv",
+		Tags: []dtrack.Tag{
+			{Name: "sbommv"},
+		},
 	}
 
 	// dtrack client will create a new project

--- a/pkg/target/dependencytrack/client.go
+++ b/pkg/target/dependencytrack/client.go
@@ -114,15 +114,24 @@ func (c *DependencyTrackClient) FindOrCreateProject(ctx *tcontext.TransferMetada
 func (c *DependencyTrackClient) CreateProject(ctx *tcontext.TransferMetadata, projectName, projectVersion string) (string, error) {
 	logger.LogDebug(ctx.Context, "Initializing Project Creation", "project", projectName, "version", projectVersion)
 
+	sourceAdapter := ctx.Value("source")
+
+	active := true
+	description := "Created & uploaded by sbommv"
+	sbommvTag := "sbommv"
+	sourceTag := sourceAdapter.(string)
+
 	project := dtrack.Project{
 		Name:        projectName,
 		Version:     projectVersion,
-		Active:      true,
-		Description: "Created & uploaded by sbommv",
+		Active:      active,
+		Description: description,
 		Tags: []dtrack.Tag{
-			{Name: "sbommv"},
+			{Name: sbommvTag},
+			{Name: sourceTag},
 		},
 	}
+	logger.LogDebug(ctx.Context, "Project is created with following parameters", "name", projectName, "version", projectVersion, "active", active, "description", description, "tag1", sbommvTag, "tag2", sourceTag)
 
 	// dtrack client will create a new project
 	created, err := c.Client.Project.Create(ctx.Context, project)


### PR DESCRIPTION
This PR adds the following:
- set the project from inactive to active
- adds the description
- and tags as `sbommv` and input adapter that would be, i.e. `github` or `folder`