### PR TITLE
monitor and fetch folder in real time and uplod it too

### DIFF
--- a/cmd/transfer.go
+++ b/cmd/transfer.go
@@ -73,6 +73,9 @@ func init() {
 	// processing mode: sequential or parallel
 	transferCmd.Flags().String("processing-mode", "parallel", "processing strategy (parallel, sequential)")
 
+	// enable daemon mode
+	transferCmd.Flags().BoolP("daemon", "d", false, "enable daemon mode")
+
 	transferCmd.Flags().BoolP("debug", "D", false, "enable debug logging")
 
 	// Manually register adapter flags for each adapter
@@ -134,6 +137,7 @@ func parseConfig(cmd *cobra.Command) (types.Config, error) {
 	outputType, _ := cmd.Flags().GetString("output-adapter")
 	dr, _ := cmd.Flags().GetBool("dry-run")
 	processingMode, _ := cmd.Flags().GetString("processing-mode")
+	daemon, _ := cmd.Flags().GetBool("daemon")
 
 	validInputAdapter := map[string]bool{"github": true, "folder": true}
 	validOutputAdapter := map[string]bool{"interlynk": true, "folder": true, "dtrack": true}
@@ -177,6 +181,7 @@ func parseConfig(cmd *cobra.Command) (types.Config, error) {
 		DestinationAdapter: outputType,
 		DryRun:             dr,
 		ProcessingStrategy: processingMode,
+		Daemon:             daemon,
 	}
 
 	return config, nil

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 )
 
 require (
-	github.com/fsnotify/fsnotify v1.8.0 // indirect
+	github.com/fsnotify/fsnotify v1.8.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/pkg/adapter/factory.go
+++ b/pkg/adapter/factory.go
@@ -63,11 +63,11 @@ func NewAdapter(ctx *tcontext.TransferMetadata, config types.Config) (map[types.
 		switch types.AdapterType(config.SourceAdapter) {
 
 		case types.GithubAdapterType:
-			adapters[types.InputAdapterRole] = &github.GitHubAdapter{Role: types.InputAdapterRole, ProcessingMode: processingMode}
+			adapters[types.InputAdapterRole] = &github.GitHubAdapter{Role: types.InputAdapterRole, ProcessingMode: processingMode, Daemon: config.Daemon}
 			inputAdp = "github"
 
 		case types.FolderAdapterType:
-			adapters[types.InputAdapterRole] = &ifolder.FolderAdapter{Role: types.InputAdapterRole, ProcessingMode: processingMode}
+			adapters[types.InputAdapterRole] = &ifolder.FolderAdapter{Role: types.InputAdapterRole, ProcessingMode: processingMode, Config: &ifolder.FolderConfig{Daemon: config.Daemon}}
 			inputAdp = "folder"
 
 		// case types.InterlynkAdapterType:

--- a/pkg/adapter/factory.go
+++ b/pkg/adapter/factory.go
@@ -40,17 +40,17 @@ type Adapter interface {
 	ParseAndValidateParams(cmd *cobra.Command) error
 
 	// Fetch SBOMs lazily using iterator
-	FetchSBOMs(ctx *tcontext.TransferMetadata) (iterator.SBOMIterator, error)
+	FetchSBOMs(ctx tcontext.TransferMetadata) (iterator.SBOMIterator, error)
 
 	// Outputs SBOMs (uploading)
-	UploadSBOMs(ctx *tcontext.TransferMetadata, iterator iterator.SBOMIterator) error
+	UploadSBOMs(ctx tcontext.TransferMetadata, iterator iterator.SBOMIterator) error
 
 	// Dry-Run: to be used to display fetched and uploaded SBOMs by input and output adapter respectively.
-	DryRun(ctx *tcontext.TransferMetadata, iterator iterator.SBOMIterator) error
+	DryRun(ctx tcontext.TransferMetadata, iterator iterator.SBOMIterator) error
 }
 
 // NewAdapter initializes and returns the correct adapters (both input & output)
-func NewAdapter(ctx *tcontext.TransferMetadata, config types.Config) (map[types.AdapterRole]Adapter, string, string, error) {
+func NewAdapter(ctx tcontext.TransferMetadata, config types.Config) (map[types.AdapterRole]Adapter, string, string, error) {
 	adapters := make(map[types.AdapterRole]Adapter)
 	var inputAdp, outputAdp string
 

--- a/pkg/iterator/iterator.go
+++ b/pkg/iterator/iterator.go
@@ -16,8 +16,11 @@
 package iterator
 
 import (
-	"context"
 	"io"
+
+	"github.com/interlynk-io/sbommv/pkg/converter"
+	"github.com/interlynk-io/sbommv/pkg/logger"
+	"github.com/interlynk-io/sbommv/pkg/tcontext"
 )
 
 // SBOM represents a single SBOM file
@@ -31,7 +34,7 @@ type SBOM struct {
 
 // SBOMIterator provides a way to lazily fetch SBOMs one by one
 type SBOMIterator interface {
-	Next(ctx context.Context) (*SBOM, error) // Fetch the next SBOM
+	Next(ctx tcontext.TransferMetadata) (*SBOM, error) // Fetch the next SBOM
 }
 
 // MemoryIterator is an iterator that iterates over a preloaded slice of SBOMs.
@@ -49,12 +52,38 @@ func NewMemoryIterator(sboms []*SBOM) SBOMIterator {
 }
 
 // Next retrieves the next SBOM in memory.
-func (it *MemoryIterator) Next(ctx context.Context) (*SBOM, error) {
+func (it *MemoryIterator) Next(ctx tcontext.TransferMetadata) (*SBOM, error) {
 	if it.index >= len(it.sboms) {
 		return nil, io.EOF // No more SBOMs left
 	}
 
 	sbom := it.sboms[it.index]
 	it.index++
+	return sbom, nil
+}
+
+type ConvertedIterator struct {
+	inner        SBOMIterator
+	targetFormat converter.FormatSpec
+}
+
+func NewConvertedIterator(inner SBOMIterator, targetFormat converter.FormatSpec) *ConvertedIterator {
+	return &ConvertedIterator{
+		inner:        inner,
+		targetFormat: targetFormat,
+	}
+}
+
+func (ci *ConvertedIterator) Next(ctx tcontext.TransferMetadata) (*SBOM, error) {
+	sbom, err := ci.inner.Next(ctx)
+	if err != nil {
+		return nil, err
+	}
+	convertedData, err := converter.ConvertSBOM(ctx, sbom.Data, ci.targetFormat)
+	if err != nil {
+		logger.LogInfo(ctx.Context, "Failed to convert SBOM", "file", sbom.Path, "error", err)
+		return sbom, nil // Fallback to original on error
+	}
+	sbom.Data = convertedData
 	return sbom, nil
 }

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -22,5 +22,5 @@ import (
 // MonitorAdapter only for input adapter
 type MonitorAdapter interface {
 	// it watches sboms and triggers as soon as the new sbom comes
-	Monitor(ctx *tcontext.TransferMetadata) (iterator.SBOMIterator, error)
+	Monitor(ctx tcontext.TransferMetadata) (iterator.SBOMIterator, error)
 }

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -11,21 +11,16 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// -------------------------------------------------------------------------
 
-package folder
+package monitor
 
-import "github.com/interlynk-io/sbommv/pkg/types"
+import (
+	"github.com/interlynk-io/sbommv/pkg/iterator"
+	"github.com/interlynk-io/sbommv/pkg/tcontext"
+)
 
-type FolderConfig struct {
-	FolderPath     string
-	Recursive      bool
-	ProcessingMode types.ProcessingMode
-	Daemon         bool
-}
-
-func NewFolderConfig() *FolderConfig {
-	return &FolderConfig{
-		ProcessingMode: types.FetchSequential, // Default
-	}
+// MonitorAdapter only for input adapter
+type MonitorAdapter interface {
+	// it watches sboms and triggers as soon as the new sbom comes
+	Monitor(ctx *tcontext.TransferMetadata) (iterator.SBOMIterator, error)
 }

--- a/pkg/source/folder/adapter.go
+++ b/pkg/source/folder/adapter.go
@@ -28,7 +28,7 @@ import (
 
 // FolderAdapter handles fetching SBOMs from folders
 type FolderAdapter struct {
-	config         *FolderConfig
+	Config         *FolderConfig
 	Role           types.AdapterRole // "input" or "output" adapter type
 	Fetcher        SBOMFetcher
 	ProcessingMode types.ProcessingMode
@@ -83,9 +83,12 @@ func (f *FolderAdapter) ParseAndValidateParams(cmd *cobra.Command) error {
 		return fmt.Errorf("invalid input adapter flag usage:\n %s\n\nUse 'sbommv transfer --help' for correct usage.", strings.Join(invalidFlags, "\n "))
 	}
 	var fetcher SBOMFetcher
+	daemon := f.Config.Daemon
 
-	// SequentialFetcher
-	if f.ProcessingMode == types.FetchSequential {
+	if daemon {
+		// daemon fether initialized
+		fetcher = NewWatcherFetcher()
+	} else if f.ProcessingMode == types.FetchSequential {
 		fetcher = &SequentialFetcher{}
 	} else if f.ProcessingMode == types.FetchParallel {
 		fetcher = &ParallelFetcher{}
@@ -94,9 +97,10 @@ func (f *FolderAdapter) ParseAndValidateParams(cmd *cobra.Command) error {
 	cfg := FolderConfig{
 		FolderPath: folderPath,
 		Recursive:  folderRecurse,
+		Daemon:     daemon,
 	}
 
-	f.config = &cfg
+	f.Config = &cfg
 	f.Fetcher = fetcher
 
 	return nil
@@ -104,8 +108,17 @@ func (f *FolderAdapter) ParseAndValidateParams(cmd *cobra.Command) error {
 
 // FetchSBOMs initializes the Folder SBOM iterator using the unified method
 func (f *FolderAdapter) FetchSBOMs(ctx *tcontext.TransferMetadata) (iterator.SBOMIterator, error) {
-	logger.LogDebug(ctx.Context, "Initializing SBOM fetching", "mode", f.config.ProcessingMode)
-	return f.Fetcher.Fetch(ctx, f.config)
+	logger.LogDebug(ctx.Context, "Initializing SBOM fetching", "mode", f.Config.ProcessingMode)
+	return f.Fetcher.Fetch(ctx, f.Config)
+}
+
+func (f *FolderAdapter) Monitor(ctx *tcontext.TransferMetadata) (iterator.SBOMIterator, error) {
+	if !f.Config.Daemon {
+		return nil, fmt.Errorf("daemon mode not enabled for folder adapter")
+	}
+
+	logger.LogDebug(ctx.Context, "Initializing SBOM monitoring")
+	return f.Fetcher.Fetch(ctx, f.Config)
 }
 
 // OutputSBOMs should return an error since Folder does not support SBOM uploads

--- a/pkg/source/folder/adapter.go
+++ b/pkg/source/folder/adapter.go
@@ -107,12 +107,12 @@ func (f *FolderAdapter) ParseAndValidateParams(cmd *cobra.Command) error {
 }
 
 // FetchSBOMs initializes the Folder SBOM iterator using the unified method
-func (f *FolderAdapter) FetchSBOMs(ctx *tcontext.TransferMetadata) (iterator.SBOMIterator, error) {
+func (f *FolderAdapter) FetchSBOMs(ctx tcontext.TransferMetadata) (iterator.SBOMIterator, error) {
 	logger.LogDebug(ctx.Context, "Initializing SBOM fetching", "mode", f.Config.ProcessingMode)
 	return f.Fetcher.Fetch(ctx, f.Config)
 }
 
-func (f *FolderAdapter) Monitor(ctx *tcontext.TransferMetadata) (iterator.SBOMIterator, error) {
+func (f *FolderAdapter) Monitor(ctx tcontext.TransferMetadata) (iterator.SBOMIterator, error) {
 	if !f.Config.Daemon {
 		return nil, fmt.Errorf("daemon mode not enabled for folder adapter")
 	}
@@ -122,12 +122,12 @@ func (f *FolderAdapter) Monitor(ctx *tcontext.TransferMetadata) (iterator.SBOMIt
 }
 
 // OutputSBOMs should return an error since Folder does not support SBOM uploads
-func (f *FolderAdapter) UploadSBOMs(ctx *tcontext.TransferMetadata, iterator iterator.SBOMIterator) error {
+func (f *FolderAdapter) UploadSBOMs(ctx tcontext.TransferMetadata, iterator iterator.SBOMIterator) error {
 	return fmt.Errorf("Folder adapter does not support SBOM uploading")
 }
 
 // DryRun for Folder Adapter: Displays all fetched SBOMs from folder adapter
-func (f *FolderAdapter) DryRun(ctx *tcontext.TransferMetadata, iter iterator.SBOMIterator) error {
+func (f *FolderAdapter) DryRun(ctx tcontext.TransferMetadata, iter iterator.SBOMIterator) error {
 	reporter := NewFolderReporter(false, "")
-	return reporter.DryRun(ctx.Context, iter)
+	return reporter.DryRun(ctx, iter)
 }

--- a/pkg/source/folder/fetcher.go
+++ b/pkg/source/folder/fetcher.go
@@ -31,7 +31,7 @@ import (
 )
 
 type SBOMFetcher interface {
-	Fetch(ctx *tcontext.TransferMetadata, config *FolderConfig) (iterator.SBOMIterator, error)
+	Fetch(ctx tcontext.TransferMetadata, config *FolderConfig) (iterator.SBOMIterator, error)
 }
 
 type SequentialFetcher struct{}
@@ -40,7 +40,7 @@ type SequentialFetcher struct{}
 // 1. Walks through the folder file-by-file
 // 2. Detects valid SBOMs using source.IsSBOMFile().
 // 3. Reads the content & adds it to the iterator along with path.
-func (f *SequentialFetcher) Fetch(ctx *tcontext.TransferMetadata, config *FolderConfig) (iterator.SBOMIterator, error) {
+func (f *SequentialFetcher) Fetch(ctx tcontext.TransferMetadata, config *FolderConfig) (iterator.SBOMIterator, error) {
 	logger.LogDebug(ctx.Context, "Fetching SBOMs Sequentially")
 
 	var sbomList []*iterator.SBOM
@@ -89,7 +89,7 @@ type ParallelFetcher struct{}
 // Fetch scans the folder for SBOMs concurrently.
 // It walks through the directory to collect file paths, then spawns a fixed number of worker goroutines
 // to read and process those files concurrently.
-func (f *ParallelFetcher) Fetch(ctx *tcontext.TransferMetadata, config *FolderConfig) (iterator.SBOMIterator, error) {
+func (f *ParallelFetcher) Fetch(ctx tcontext.TransferMetadata, config *FolderConfig) (iterator.SBOMIterator, error) {
 	logger.LogDebug(ctx.Context, "Fetching SBOMs Parallely")
 	filePaths := make(chan string, 100)
 	var wg sync.WaitGroup

--- a/pkg/source/folder/iterator.go
+++ b/pkg/source/folder/iterator.go
@@ -15,11 +15,11 @@
 package folder
 
 import (
-	"context"
 	"fmt"
 	"io"
 
 	"github.com/interlynk-io/sbommv/pkg/iterator"
+	"github.com/interlynk-io/sbommv/pkg/tcontext"
 )
 
 // FolderIterator iterates over SBOMs found in a folder
@@ -37,7 +37,7 @@ func NewFolderIterator(sboms []*iterator.SBOM) *FolderIterator {
 }
 
 // Next retrieves the next SBOM in the iteration
-func (it *FolderIterator) Next(ctx context.Context) (*iterator.SBOM, error) {
+func (it *FolderIterator) Next(ctx tcontext.TransferMetadata) (*iterator.SBOM, error) {
 	if it.index >= len(it.sboms) {
 		return nil, io.EOF
 	}
@@ -52,7 +52,7 @@ type WatcherIterator struct {
 	sbomChan chan *iterator.SBOM
 }
 
-func (it *WatcherIterator) Next(ctx context.Context) (*iterator.SBOM, error) {
+func (it *WatcherIterator) Next(ctx tcontext.TransferMetadata) (*iterator.SBOM, error) {
 	select {
 	case sbom, ok := <-it.sbomChan:
 		if !ok {

--- a/pkg/source/folder/reporter.go
+++ b/pkg/source/folder/reporter.go
@@ -16,13 +16,13 @@
 package folder
 
 import (
-	"context"
 	"fmt"
 	"io"
 
 	"github.com/interlynk-io/sbommv/pkg/iterator"
 	"github.com/interlynk-io/sbommv/pkg/logger"
 	"github.com/interlynk-io/sbommv/pkg/sbom"
+	"github.com/interlynk-io/sbommv/pkg/tcontext"
 )
 
 type FolderReporter struct {
@@ -34,8 +34,8 @@ func NewFolderReporter(verbose bool, outputDir string) *FolderReporter {
 	return &FolderReporter{verbose: verbose, outputDir: outputDir}
 }
 
-func (r *FolderReporter) DryRun(ctx context.Context, iter iterator.SBOMIterator) error {
-	logger.LogDebug(ctx, "Dry-run mode: Displaying SBOMs fetched from folder")
+func (r *FolderReporter) DryRun(ctx tcontext.TransferMetadata, iter iterator.SBOMIterator) error {
+	logger.LogDebug(ctx.Context, "Dry-run mode: Displaying SBOMs fetched from folder")
 	processor := sbom.NewSBOMProcessor(r.outputDir, r.verbose)
 	sbomCount := 0
 	fmt.Println("\n📦 Details of all Fetched SBOMs by Folder Input Adapter")
@@ -46,18 +46,18 @@ func (r *FolderReporter) DryRun(ctx context.Context, iter iterator.SBOMIterator)
 			break
 		}
 		if err != nil {
-			logger.LogError(ctx, err, "Error retrieving SBOM from iterator")
+			logger.LogError(ctx.Context, err, "Error retrieving SBOM from iterator")
 			return err
 		}
 		processor.Update(sbom.Data, "", sbom.Path)
 		doc, err := processor.ProcessSBOMs()
 		if err != nil {
-			logger.LogError(ctx, err, "Failed to process SBOM")
+			logger.LogError(ctx.Context, err, "Failed to process SBOM")
 			return err
 		}
 		if r.outputDir != "" {
 			if err := processor.WriteSBOM(doc, ""); err != nil {
-				logger.LogError(ctx, err, "Failed to write SBOM")
+				logger.LogError(ctx.Context, err, "Failed to write SBOM")
 				return err
 			}
 		}

--- a/pkg/source/folder/watcher.go
+++ b/pkg/source/folder/watcher.go
@@ -35,7 +35,7 @@ func NewWatcherFetcher() *WatcherFetcher {
 	return &WatcherFetcher{}
 }
 
-func (f *WatcherFetcher) Fetch(ctx *tcontext.TransferMetadata, config *FolderConfig) (iterator.SBOMIterator, error) {
+func (f *WatcherFetcher) Fetch(ctx tcontext.TransferMetadata, config *FolderConfig) (iterator.SBOMIterator, error) {
 	logger.LogDebug(ctx.Context, "Starting folder watcher", "path", config.FolderPath, "recurssive", config.ProcessingMode)
 
 	// Create new watcher.
@@ -122,19 +122,3 @@ func (f *WatcherFetcher) Fetch(ctx *tcontext.TransferMetadata, config *FolderCon
 
 	return &WatcherIterator{sbomChan: sbomChan}, nil
 }
-
-// type WatcherIterator struct {
-// 	sbomChan chan *iterator.SBOM
-// }
-
-// func (it *WatcherIterator) Next(ctx context.Context) (*iterator.SBOM, error) {
-// 	select {
-// 	case sbom, ok := <-it.sbomChan:
-// 		if !ok {
-// 			return nil, fmt.Errorf("watcher channel closed")
-// 		}
-// 		return sbom, nil
-// 	case <-ctx.Done():
-// 		return nil, ctx.Err()
-// 	}
-// }

--- a/pkg/source/folder/watcher.go
+++ b/pkg/source/folder/watcher.go
@@ -1,0 +1,140 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -------------------------------------------------------------------------
+
+package folder
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/interlynk-io/sbommv/pkg/iterator"
+	"github.com/interlynk-io/sbommv/pkg/logger"
+	"github.com/interlynk-io/sbommv/pkg/sbom"
+	"github.com/interlynk-io/sbommv/pkg/source"
+	"github.com/interlynk-io/sbommv/pkg/tcontext"
+)
+
+type WatcherFetcher struct{}
+
+func NewWatcherFetcher() *WatcherFetcher {
+	return &WatcherFetcher{}
+}
+
+func (f *WatcherFetcher) Fetch(ctx *tcontext.TransferMetadata, config *FolderConfig) (iterator.SBOMIterator, error) {
+	logger.LogDebug(ctx.Context, "Starting folder watcher", "path", config.FolderPath, "recurssive", config.ProcessingMode)
+
+	// Create new watcher.
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create watcher: %w", err)
+	}
+
+	sbomChan := make(chan *iterator.SBOM, 10)
+
+	// add to watch more sub-directories if recurssive is true
+	err = filepath.Walk(config.FolderPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			logger.LogError(ctx.Context, err, "Error accessing path", "path", path)
+			return nil
+		}
+		if info.IsDir() {
+			if !config.Recursive && path != config.FolderPath {
+				return filepath.SkipDir
+			}
+
+			// add it to the watcher
+			if err := watcher.Add(path); err != nil {
+				logger.LogError(ctx.Context, err, "Failed to watch directory", "path", path)
+			} else {
+				logger.LogDebug(ctx.Context, "Watching directory", "path", path)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		watcher.Close()
+		return nil, fmt.Errorf("failed to walk directory: %w", err)
+	}
+
+	// Start listening for events.
+	go func() {
+		defer watcher.Close()
+		for {
+			select {
+			case event, ok := <-watcher.Events:
+				if !ok {
+					close(sbomChan)
+					return
+				}
+				log.Println("event:", event)
+				// if event.Has(fsnotify.Write) {
+				// 	log.Println("modified file:", event.Name)
+				// }
+
+				if event.Op&(fsnotify.Create|fsnotify.Write) != 0 && source.IsSBOMFile(event.Name) {
+					content, err := os.ReadFile(event.Name)
+					if err != nil {
+						logger.LogError(ctx.Context, err, "Failed to read SBOM", "path", event.Name)
+						continue
+					}
+
+					primaryComp, err := sbom.ExtractPrimaryComponentName(content)
+					if err != nil {
+						logger.LogDebug(ctx.Context, "Failed to parse SBOM for primary component", "path", event.Name, "error", err)
+					}
+
+					fileName := getFilePath(config.FolderPath, event.Name)
+					logger.LogDebug(ctx.Context, "Detected SBOM", "file", fileName)
+					sbomChan <- &iterator.SBOM{
+						Data:      content,
+						Path:      fileName,
+						Namespace: primaryComp,
+					}
+				}
+			case err, ok := <-watcher.Errors:
+				if !ok {
+					close(sbomChan)
+					return
+				}
+				logger.LogError(ctx.Context, err, "Watcher error")
+
+			case <-ctx.Done():
+				close(sbomChan)
+				return
+			}
+		}
+	}()
+
+	return &WatcherIterator{sbomChan: sbomChan}, nil
+}
+
+// type WatcherIterator struct {
+// 	sbomChan chan *iterator.SBOM
+// }
+
+// func (it *WatcherIterator) Next(ctx context.Context) (*iterator.SBOM, error) {
+// 	select {
+// 	case sbom, ok := <-it.sbomChan:
+// 		if !ok {
+// 			return nil, fmt.Errorf("watcher channel closed")
+// 		}
+// 		return sbom, nil
+// 	case <-ctx.Done():
+// 		return nil, ctx.Err()
+// 	}
+// }

--- a/pkg/source/folder/watcher.go
+++ b/pkg/source/folder/watcher.go
@@ -17,7 +17,6 @@ package folder
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -81,12 +80,12 @@ func (f *WatcherFetcher) Fetch(ctx tcontext.TransferMetadata, config *FolderConf
 					close(sbomChan)
 					return
 				}
-				log.Println("event:", event)
-				// if event.Has(fsnotify.Write) {
-				// 	log.Println("modified file:", event.Name)
-				// }
+				logger.LogDebug(ctx.Context, "Event Triggered", "name", event)
+				if event.Has(fsnotify.Write) {
+					logger.LogInfo(ctx.Context, "Event Triggered", "name", event)
+				}
 
-				if event.Op&(fsnotify.Create|fsnotify.Write) != 0 && source.IsSBOMFile(event.Name) {
+				if event.Op&(fsnotify.Write) != 0 && source.IsSBOMFile(event.Name) {
 					content, err := os.ReadFile(event.Name)
 					if err != nil {
 						logger.LogError(ctx.Context, err, "Failed to read SBOM", "path", event.Name)

--- a/pkg/source/github/adapter.go
+++ b/pkg/source/github/adapter.go
@@ -486,7 +486,6 @@ func (g *GitHubAdapter) fetchSBOMsConcurrently(ctx tcontext.TransferMetadata, re
 // fetchSBOMsSequentially: fetch SBOMs from repositories one at a time
 func (g *GitHubAdapter) fetchSBOMsSequentially(ctx tcontext.TransferMetadata, repos []string) (iterator.SBOMIterator, error) {
 	logger.LogDebug(ctx.Context, "Fetching SBOMs sequentially")
-	fmt.Println("Fetching SBOMs sequentially")
 
 	var sbomList []*iterator.SBOM
 	giter := &GitHubIterator{client: g.client}
@@ -517,7 +516,6 @@ func (g *GitHubAdapter) fetchSBOMsSequentially(ctx tcontext.TransferMetadata, re
 				logger.LogInfo(ctx.Context, "Failed to fetch SBOMs from Release Method for", "repo", repo)
 				continue
 			}
-			fmt.Println("releaseSBOMs: ", len(releaseSBOMs))
 			sbomList = append(sbomList, releaseSBOMs...)
 
 		case MethodTool:
@@ -538,8 +536,6 @@ func (g *GitHubAdapter) fetchSBOMsSequentially(ctx tcontext.TransferMetadata, re
 	if len(sbomList) == 0 {
 		return nil, fmt.Errorf("no SBOMs found for any repository")
 	}
-
-	fmt.Println("finalSbomList: ", len(sbomList))
 
 	return &GitHubIterator{
 		sboms: sbomList,

--- a/pkg/source/github/adapter.go
+++ b/pkg/source/github/adapter.go
@@ -227,7 +227,7 @@ func (g *GitHubAdapter) ParseAndValidateParams(cmd *cobra.Command) error {
 }
 
 // FetchSBOMs initializes the GitHub SBOM iterator using the unified method
-func (g *GitHubAdapter) FetchSBOMs(ctx *tcontext.TransferMetadata) (iterator.SBOMIterator, error) {
+func (g *GitHubAdapter) FetchSBOMs(ctx tcontext.TransferMetadata) (iterator.SBOMIterator, error) {
 	logger.LogDebug(ctx.Context, "Intializing SBOM fetching process")
 
 	// Org Mode: Fetch all repositories
@@ -268,17 +268,17 @@ func (g *GitHubAdapter) FetchSBOMs(ctx *tcontext.TransferMetadata) (iterator.SBO
 	return sbomIterator, err
 }
 
-func (g *GitHubAdapter) Monitor(ctx *tcontext.TransferMetadata) (iterator.SBOMIterator, *tcontext.TransferMetadata, error) {
+func (g *GitHubAdapter) Monitor(ctx tcontext.TransferMetadata) (iterator.SBOMIterator, tcontext.TransferMetadata, error) {
 	return nil, ctx, fmt.Errorf("Currently gitHub adapter does not support monitoring")
 }
 
 // OutputSBOMs should return an error since GitHub does not support SBOM uploads
-func (g *GitHubAdapter) UploadSBOMs(ctx *tcontext.TransferMetadata, iterator iterator.SBOMIterator) error {
+func (g *GitHubAdapter) UploadSBOMs(ctx tcontext.TransferMetadata, iterator iterator.SBOMIterator) error {
 	return fmt.Errorf("GitHub adapter does not support SBOM uploading")
 }
 
 // DryRun for Input Adapter: Displays all fetched SBOMs from input adapter
-func (g *GitHubAdapter) DryRun(ctx *tcontext.TransferMetadata, iterator iterator.SBOMIterator) error {
+func (g *GitHubAdapter) DryRun(ctx tcontext.TransferMetadata, iterator iterator.SBOMIterator) error {
 	logger.LogDebug(ctx.Context, "Dry-run mode: Displaying SBOMs fetched from input adapter")
 
 	var outputDir string
@@ -291,7 +291,7 @@ func (g *GitHubAdapter) DryRun(ctx *tcontext.TransferMetadata, iterator iterator
 
 	for {
 
-		sbom, err := iterator.Next(ctx.Context)
+		sbom, err := iterator.Next(ctx)
 		if err == io.EOF {
 			break // No more SBOMs
 		}
@@ -374,12 +374,12 @@ func (g *GitHubAdapter) applyRepoFilters(repos []string) []string {
 	return filteredRepos
 }
 
-func (g *GitHubAdapter) fetchWatcher(ctx *tcontext.TransferMetadata, repos []string) (iterator.SBOMIterator, error) {
+func (g *GitHubAdapter) fetchWatcher(ctx tcontext.TransferMetadata, repos []string) (iterator.SBOMIterator, error) {
 	logger.LogInfo(ctx.Context, "Monitoring SBOM via github adapter currently doesn't support")
 	return nil, nil
 }
 
-func (g *GitHubAdapter) fetchSBOMsConcurrently(ctx *tcontext.TransferMetadata, repos []string) (iterator.SBOMIterator, error) {
+func (g *GitHubAdapter) fetchSBOMsConcurrently(ctx tcontext.TransferMetadata, repos []string) (iterator.SBOMIterator, error) {
 	logger.LogDebug(ctx.Context, "Fetching SBOMs concurrently")
 	const maxWorkers = 5        // Number of concurrent workers (adjustable)
 	const requestsPerSecond = 5 // Rate limit for GitHub API requests
@@ -484,7 +484,7 @@ func (g *GitHubAdapter) fetchSBOMsConcurrently(ctx *tcontext.TransferMetadata, r
 }
 
 // fetchSBOMsSequentially: fetch SBOMs from repositories one at a time
-func (g *GitHubAdapter) fetchSBOMsSequentially(ctx *tcontext.TransferMetadata, repos []string) (iterator.SBOMIterator, error) {
+func (g *GitHubAdapter) fetchSBOMsSequentially(ctx tcontext.TransferMetadata, repos []string) (iterator.SBOMIterator, error) {
 	logger.LogDebug(ctx.Context, "Fetching SBOMs sequentially")
 	fmt.Println("Fetching SBOMs sequentially")
 

--- a/pkg/source/github/adapter.go
+++ b/pkg/source/github/adapter.go
@@ -46,6 +46,7 @@ type GitHubAdapter struct {
 	GithubToken    string
 	Role           types.AdapterRole
 	ProcessingMode types.ProcessingMode
+	Daemon         bool
 
 	// Comma-separated list (e.g., "repo1,repo2")
 	IncludeRepos []string

--- a/pkg/source/github/adapter.go
+++ b/pkg/source/github/adapter.go
@@ -268,6 +268,10 @@ func (g *GitHubAdapter) FetchSBOMs(ctx *tcontext.TransferMetadata) (iterator.SBO
 	return sbomIterator, err
 }
 
+func (g *GitHubAdapter) Monitor(ctx *tcontext.TransferMetadata) (iterator.SBOMIterator, *tcontext.TransferMetadata, error) {
+	return nil, ctx, fmt.Errorf("Currently gitHub adapter does not support monitoring")
+}
+
 // OutputSBOMs should return an error since GitHub does not support SBOM uploads
 func (g *GitHubAdapter) UploadSBOMs(ctx *tcontext.TransferMetadata, iterator iterator.SBOMIterator) error {
 	return fmt.Errorf("GitHub adapter does not support SBOM uploading")
@@ -368,6 +372,11 @@ func (g *GitHubAdapter) applyRepoFilters(repos []string) []string {
 	}
 
 	return filteredRepos
+}
+
+func (g *GitHubAdapter) fetchWatcher(ctx *tcontext.TransferMetadata, repos []string) (iterator.SBOMIterator, error) {
+	logger.LogInfo(ctx.Context, "Monitoring SBOM via github adapter currently doesn't support")
+	return nil, nil
 }
 
 func (g *GitHubAdapter) fetchSBOMsConcurrently(ctx *tcontext.TransferMetadata, repos []string) (iterator.SBOMIterator, error) {

--- a/pkg/source/github/client.go
+++ b/pkg/source/github/client.go
@@ -100,7 +100,7 @@ func NewClient(g *GitHubAdapter) *Client {
 // FindSBOMs gets all releases assets from github release page
 // filter out the particular provided release asset and
 // extract SBOMs from that
-func (c *Client) FindSBOMs(ctx *tcontext.TransferMetadata) ([]SBOMAsset, error) {
+func (c *Client) FindSBOMs(ctx tcontext.TransferMetadata) ([]SBOMAsset, error) {
 	logger.LogDebug(ctx.Context, "Fetching SBOMs from GitHub releases", "repo_url", c.RepoURL, "owner", c.Owner, "repo", c.Repo)
 
 	releases, err := c.GetReleases(ctx, c.Owner, c.Repo)
@@ -170,7 +170,7 @@ func (c *Client) extractSBOMs(releases []Release) []SBOMAsset {
 }
 
 // GetReleases fetches all releases for a repository
-func (c *Client) GetReleases(ctx *tcontext.TransferMetadata, owner, repo string) ([]Release, error) {
+func (c *Client) GetReleases(ctx tcontext.TransferMetadata, owner, repo string) ([]Release, error) {
 	url := fmt.Sprintf("%s/repos/%s/%s/releases", c.BaseURL, owner, repo)
 	logger.LogDebug(ctx.Context, "Constructed GitHub Releases", "url", url)
 
@@ -229,7 +229,7 @@ func (c *Client) GetReleases(ctx *tcontext.TransferMetadata, owner, repo string)
 }
 
 // DownloadAsset downloads a release asset from download url of SBOM
-func (c *Client) DownloadAsset(ctx *tcontext.TransferMetadata, downloadURL string) (io.ReadCloser, error) {
+func (c *Client) DownloadAsset(ctx tcontext.TransferMetadata, downloadURL string) (io.ReadCloser, error) {
 	req, err := http.NewRequestWithContext(ctx.Context, "GET", downloadURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating request failed: %w", err)
@@ -249,7 +249,7 @@ func (c *Client) DownloadAsset(ctx *tcontext.TransferMetadata, downloadURL strin
 }
 
 // GetSBOMs downloads and saves all SBOM files found in the repository
-func (c *Client) FetchSBOMFromReleases(ctx *tcontext.TransferMetadata) (VersionedSBOMs, error) {
+func (c *Client) FetchSBOMFromReleases(ctx tcontext.TransferMetadata) (VersionedSBOMs, error) {
 	logger.LogDebug(ctx.Context, "Initializing fetching of SBOMs from repo", "repository", c.Repo, "version", c.Version)
 	// Find SBOMs in releases
 	sboms, err := c.FindSBOMs(ctx)
@@ -267,7 +267,7 @@ func (c *Client) FetchSBOMFromReleases(ctx *tcontext.TransferMetadata) (Versione
 }
 
 // downloadSBOMs handles the concurrent downloading of multiple SBOM files
-func (c *Client) downloadSBOMs(ctx *tcontext.TransferMetadata, sboms []SBOMAsset) (VersionedSBOMs, error) {
+func (c *Client) downloadSBOMs(ctx tcontext.TransferMetadata, sboms []SBOMAsset) (VersionedSBOMs, error) {
 	var (
 		wg             sync.WaitGroup                        // Coordinates all goroutines
 		mu             sync.Mutex                            // Protects shared resources
@@ -329,7 +329,7 @@ func (c *Client) downloadSBOMs(ctx *tcontext.TransferMetadata, sboms []SBOMAsset
 }
 
 // downloadSingleSBOM downloads a single SBOM and stores it in memory
-func (c *Client) downloadSingleSBOM(ctx *tcontext.TransferMetadata, sbom SBOMAsset) ([]byte, error) {
+func (c *Client) downloadSingleSBOM(ctx tcontext.TransferMetadata, sbom SBOMAsset) ([]byte, error) {
 	reader, err := c.DownloadAsset(ctx, sbom.DownloadURL)
 	if err != nil {
 		return nil, fmt.Errorf("downloading asset: %w", err)
@@ -346,7 +346,7 @@ func (c *Client) downloadSingleSBOM(ctx *tcontext.TransferMetadata, sbom SBOMAss
 	return sbomData, nil
 }
 
-func (c *Client) FetchSBOMFromAPI(ctx *tcontext.TransferMetadata) ([]byte, error) {
+func (c *Client) FetchSBOMFromAPI(ctx tcontext.TransferMetadata) ([]byte, error) {
 	owner, repo, err := source.ParseGitHubURL(c.RepoURL)
 	if err != nil {
 		return nil, fmt.Errorf("parsing GitHub URL: %w", err)
@@ -411,7 +411,7 @@ func (c *Client) updateRepo(repo string) {
 	c.RepoURL = fmt.Sprintf("https://github.com/%s/%s", c.Owner, repo)
 }
 
-func (c *Client) GetAllRepositories(ctx *tcontext.TransferMetadata) ([]string, error) {
+func (c *Client) GetAllRepositories(ctx tcontext.TransferMetadata) ([]string, error) {
 	if c.Repo != "" {
 		return []string{c.Repo}, nil
 	}

--- a/pkg/source/github/iterator.go
+++ b/pkg/source/github/iterator.go
@@ -15,7 +15,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -35,7 +34,7 @@ type GitHubIterator struct {
 }
 
 // NewGitHubIterator initializes and returns a new GitHubIterator instance
-func NewGitHubIterator(ctx *tcontext.TransferMetadata, g *GitHubAdapter, repo string) *GitHubIterator {
+func NewGitHubIterator(ctx tcontext.TransferMetadata, g *GitHubAdapter, repo string) *GitHubIterator {
 	logger.LogDebug(ctx.Context, "Initializing GitHub Iterator", "repo", g.URL, "method", g.Method, "repo", repo)
 
 	g.client.updateRepo(repo)
@@ -49,7 +48,7 @@ func NewGitHubIterator(ctx *tcontext.TransferMetadata, g *GitHubAdapter, repo st
 }
 
 // Next returns the next SBOM from the stored list
-func (it *GitHubIterator) Next(ctx context.Context) (*iterator.SBOM, error) {
+func (it *GitHubIterator) Next(ctx tcontext.TransferMetadata) (*iterator.SBOM, error) {
 	if it.position >= len(it.sboms) {
 		return nil, io.EOF // No more SBOMs left
 	}
@@ -60,7 +59,7 @@ func (it *GitHubIterator) Next(ctx context.Context) (*iterator.SBOM, error) {
 }
 
 // Fetch SBOM via GitHub API
-func (it *GitHubIterator) fetchSBOMFromAPI(ctx *tcontext.TransferMetadata) ([]*iterator.SBOM, error) {
+func (it *GitHubIterator) fetchSBOMFromAPI(ctx tcontext.TransferMetadata) ([]*iterator.SBOM, error) {
 	sbomData, err := it.client.FetchSBOMFromAPI(ctx)
 	if err != nil {
 		return nil, err
@@ -78,7 +77,7 @@ func (it *GitHubIterator) fetchSBOMFromAPI(ctx *tcontext.TransferMetadata) ([]*i
 }
 
 // Fetch SBOMs from GitHub Releases
-func (it *GitHubIterator) fetchSBOMFromReleases(ctx *tcontext.TransferMetadata) ([]*iterator.SBOM, error) {
+func (it *GitHubIterator) fetchSBOMFromReleases(ctx tcontext.TransferMetadata) ([]*iterator.SBOM, error) {
 	sbomFiles, err := it.client.FetchSBOMFromReleases(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving SBOMs from releases: %w", err)
@@ -100,7 +99,7 @@ func (it *GitHubIterator) fetchSBOMFromReleases(ctx *tcontext.TransferMetadata) 
 	return sbomSlice, nil
 }
 
-func (it *GitHubIterator) fetchSBOMFromTool(ctx *tcontext.TransferMetadata) ([]*iterator.SBOM, error) {
+func (it *GitHubIterator) fetchSBOMFromTool(ctx tcontext.TransferMetadata) ([]*iterator.SBOM, error) {
 	logger.LogDebug(ctx.Context, "Generating SBOM using Tool", "repository", it.client.RepoURL)
 
 	var sbomSlice []*iterator.SBOM

--- a/pkg/source/github/tool.go
+++ b/pkg/source/github/tool.go
@@ -33,7 +33,7 @@ var SupportedTools = map[string]string{
 	"spdxgen": "https://github.com/spdx/spdx-sbom-generator.git",
 }
 
-func GenerateSBOM(ctx *tcontext.TransferMetadata, repoDir, binaryPath string) (string, error) {
+func GenerateSBOM(ctx tcontext.TransferMetadata, repoDir, binaryPath string) (string, error) {
 	logger.LogDebug(ctx.Context, "Generating SBOM using Syft", "repo_dir", repoDir)
 
 	// Ensure Syft binary is executable
@@ -78,7 +78,7 @@ func GenerateSBOM(ctx *tcontext.TransferMetadata, repoDir, binaryPath string) (s
 }
 
 // CloneRepoWithGit clones a GitHub repository using the Git command-line tool.
-func CloneRepoWithGit(ctx *tcontext.TransferMetadata, repoURL, branch, targetDir string) error {
+func CloneRepoWithGit(ctx tcontext.TransferMetadata, repoURL, branch, targetDir string) error {
 	// Ensure Git is installed
 	if _, err := exec.LookPath("git"); err != nil {
 		return fmt.Errorf("git is not installed, install Git or use --method=api")

--- a/pkg/target/dependencytrack/adapter.go
+++ b/pkg/target/dependencytrack/adapter.go
@@ -104,7 +104,6 @@ func (d *DependencyTrackAdapter) ParseAndValidateParams(cmd *cobra.Command) erro
 		uploader = NewParallelUploader()
 	}
 
-	fmt.Println("uploader: ", uploader)
 	cfg := NewDependencyTrackConfig()
 	cfg.APIURL = apiURL
 	cfg.APIKey = token
@@ -129,15 +128,15 @@ func (d *DependencyTrackAdapter) ParseAndValidateParams(cmd *cobra.Command) erro
 }
 
 // FetchSBOMs returns an error since Dependency-Track is an output adapter
-func (d *DependencyTrackAdapter) FetchSBOMs(ctx *tcontext.TransferMetadata) (iterator.SBOMIterator, error) {
+func (d *DependencyTrackAdapter) FetchSBOMs(ctx tcontext.TransferMetadata) (iterator.SBOMIterator, error) {
 	return nil, fmt.Errorf("Dependency-Track adapter does not support SBOM fetching")
 }
 
-func (d *DependencyTrackAdapter) UploadSBOMs(ctx *tcontext.TransferMetadata, iter iterator.SBOMIterator) error {
+func (d *DependencyTrackAdapter) UploadSBOMs(ctx tcontext.TransferMetadata, iter iterator.SBOMIterator) error {
 	return d.Uploader.Upload(ctx, d.Config, d.client, iter)
 }
 
-func (d *DependencyTrackAdapter) DryRun(ctx *tcontext.TransferMetadata, iter iterator.SBOMIterator) error {
+func (d *DependencyTrackAdapter) DryRun(ctx tcontext.TransferMetadata, iter iterator.SBOMIterator) error {
 	reporter := NewDependencyTrackReporter(d.Config.APIURL, d.Config.ProjectName)
-	return reporter.DryRun(ctx.Context, iter)
+	return reporter.DryRun(ctx, iter)
 }

--- a/pkg/target/dependencytrack/client.go
+++ b/pkg/target/dependencytrack/client.go
@@ -48,7 +48,7 @@ type Project struct {
 	Version string `json:"version"`
 }
 
-func (c *DependencyTrackClient) FindProject(ctx *tcontext.TransferMetadata, projectName, projectVersion string) (string, error) {
+func (c *DependencyTrackClient) FindProject(ctx tcontext.TransferMetadata, projectName, projectVersion string) (string, error) {
 	logger.LogDebug(ctx.Context, "Finding Project", "project", projectName, "version", projectVersion)
 
 	// dtrack client, retrives all projects
@@ -72,7 +72,7 @@ func (c *DependencyTrackClient) FindProject(ctx *tcontext.TransferMetadata, proj
 }
 
 // UploadSBOM uploads an SBOM to a Dependency-Track project
-func (c *DependencyTrackClient) UploadSBOM(ctx *tcontext.TransferMetadata, projectName, projectVersion string, sbomData []byte) error {
+func (c *DependencyTrackClient) UploadSBOM(ctx tcontext.TransferMetadata, projectName, projectVersion string, sbomData []byte) error {
 	logger.LogDebug(ctx.Context, "Processing Uploading SBOMs", "project", projectName, "version", projectVersion)
 
 	bomReq := dtrack.BOMUploadRequest{
@@ -92,7 +92,7 @@ func (c *DependencyTrackClient) UploadSBOM(ctx *tcontext.TransferMetadata, proje
 }
 
 // FindOrCreateProject ensures a project exists, returning its UUID after finding or creating project
-func (c *DependencyTrackClient) FindOrCreateProject(ctx *tcontext.TransferMetadata, projectName, projectVersion string) (string, error) {
+func (c *DependencyTrackClient) FindOrCreateProject(ctx tcontext.TransferMetadata, projectName, projectVersion string) (string, error) {
 	logger.LogDebug(ctx.Context, "Processing finding or Creating Project", "project", projectName, "version", projectVersion)
 
 	// find project using project name and project version
@@ -111,7 +111,7 @@ func (c *DependencyTrackClient) FindOrCreateProject(ctx *tcontext.TransferMetada
 }
 
 // CreateProject creates a new project if it doesn’t exist
-func (c *DependencyTrackClient) CreateProject(ctx *tcontext.TransferMetadata, projectName, projectVersion string) (string, error) {
+func (c *DependencyTrackClient) CreateProject(ctx tcontext.TransferMetadata, projectName, projectVersion string) (string, error) {
 	logger.LogDebug(ctx.Context, "Initializing Project Creation", "project", projectName, "version", projectVersion)
 
 	sourceAdapter := ctx.Value("source")

--- a/pkg/target/dependencytrack/reporter.go
+++ b/pkg/target/dependencytrack/reporter.go
@@ -15,13 +15,13 @@
 package dependencytrack
 
 import (
-	"context"
 	"fmt"
 	"io"
 
 	"github.com/interlynk-io/sbommv/pkg/iterator"
 	"github.com/interlynk-io/sbommv/pkg/logger"
 	"github.com/interlynk-io/sbommv/pkg/sbom"
+	"github.com/interlynk-io/sbommv/pkg/tcontext"
 )
 
 type DependencyTrackReporter struct {
@@ -36,8 +36,8 @@ func NewDependencyTrackReporter(apiURL, projectName string) *DependencyTrackRepo
 	}
 }
 
-func (r *DependencyTrackReporter) DryRun(ctx context.Context, iter iterator.SBOMIterator) error {
-	logger.LogDebug(ctx, "Dry-run mode: Simulating SBOM upload to Dependency-Track")
+func (r *DependencyTrackReporter) DryRun(ctx tcontext.TransferMetadata, iter iterator.SBOMIterator) error {
+	logger.LogDebug(ctx.Context, "Dry-run mode: Simulating SBOM upload to Dependency-Track")
 	fmt.Println("\n📦 **Dependency-Track Output Adapter Dry-Run**")
 	fmt.Printf("API Endpoint: %s\n", r.apiURL)
 	fmt.Printf("Target Project: %s\n", r.projectName)
@@ -50,13 +50,13 @@ func (r *DependencyTrackReporter) DryRun(ctx context.Context, iter iterator.SBOM
 			break
 		}
 		if err != nil {
-			logger.LogError(ctx, err, "Error retrieving SBOM")
+			logger.LogError(ctx.Context, err, "Error retrieving SBOM")
 			return err
 		}
 		processor.Update(sbom.Data, sbom.Namespace, "")
 		doc, err := processor.ProcessSBOMs()
 		if err != nil {
-			logger.LogError(ctx, err, "Failed to process SBOM")
+			logger.LogError(ctx.Context, err, "Failed to process SBOM")
 			return err
 		}
 		projectName := sbom.Namespace

--- a/pkg/target/dependencytrack/uploader.go
+++ b/pkg/target/dependencytrack/uploader.go
@@ -40,6 +40,7 @@ func NewSequentialUploader() *SequentialUploader {
 
 func (u *SequentialUploader) Upload(ctx tcontext.TransferMetadata, config *DependencyTrackConfig, client *DependencyTrackClient, iter iterator.SBOMIterator) error {
 	logger.LogDebug(ctx.Context, "Uploading SBOMs to Dependency-Track sequentially")
+
 	totalSBOMs := 0
 	successfullyUploaded := 0
 	for {
@@ -73,19 +74,19 @@ func (u *SequentialUploader) Upload(ctx tcontext.TransferMetadata, config *Depen
 			projectVersion = "latest"
 		}
 
-		u.mu.Lock()
+		// u.mu.Lock()
 		if !u.createdProjects[projectName] {
 
 			// find or create project using project name and project version
 			_, err = client.FindOrCreateProject(ctx, projectName, projectVersion)
 			if err != nil {
 				logger.LogInfo(ctx.Context, "Failed to find or create project", "project", projectName, "error", err)
-				u.mu.Unlock()
+				// u.mu.Unlock()
 				continue
 			}
 			u.createdProjects[projectName] = true
 		}
-		u.mu.Unlock()
+		// u.mu.Unlock()
 
 		// Log SBOM filename before upload
 		logger.LogDebug(ctx.Context, "Iniatializing uploading SBOM file", "file", sbom.Path)
@@ -101,7 +102,7 @@ func (u *SequentialUploader) Upload(ctx tcontext.TransferMetadata, config *Depen
 	return nil
 }
 
-// ParallelUploader uploads SBOMs to Dependency-Track concurrently.
+// // ParallelUploader uploads SBOMs to Dependency-Track concurrently.
 type ParallelUploader struct {
 	createdProjects map[string]bool
 	mu              sync.Mutex // Protects access to createdProjects.

--- a/pkg/target/dependencytrack/uploader.go
+++ b/pkg/target/dependencytrack/uploader.go
@@ -24,7 +24,7 @@ import (
 )
 
 type SBOMUploader interface {
-	Upload(ctx *tcontext.TransferMetadata, config *DependencyTrackConfig, client *DependencyTrackClient, iter iterator.SBOMIterator) error
+	Upload(ctx tcontext.TransferMetadata, config *DependencyTrackConfig, client *DependencyTrackClient, iter iterator.SBOMIterator) error
 }
 
 type SequentialUploader struct {
@@ -38,12 +38,12 @@ func NewSequentialUploader() *SequentialUploader {
 	}
 }
 
-func (u *SequentialUploader) Upload(ctx *tcontext.TransferMetadata, config *DependencyTrackConfig, client *DependencyTrackClient, iter iterator.SBOMIterator) error {
+func (u *SequentialUploader) Upload(ctx tcontext.TransferMetadata, config *DependencyTrackConfig, client *DependencyTrackClient, iter iterator.SBOMIterator) error {
 	logger.LogDebug(ctx.Context, "Uploading SBOMs to Dependency-Track sequentially")
 	totalSBOMs := 0
 	successfullyUploaded := 0
 	for {
-		sbom, err := iter.Next(ctx.Context)
+		sbom, err := iter.Next(ctx)
 		if err == io.EOF {
 			logger.LogInfo(ctx.Context, "All SBOMs uploaded successfully, no more SBOMs left")
 			logger.LogInfo(ctx.Context, "Total SBOMs", "count", totalSBOMs)
@@ -115,7 +115,7 @@ func NewParallelUploader() *ParallelUploader {
 }
 
 // Upload implements the SBOMUploader interface for ParallelUploader.
-func (u *ParallelUploader) Upload(ctx *tcontext.TransferMetadata, config *DependencyTrackConfig, client *DependencyTrackClient, iter iterator.SBOMIterator) error {
+func (u *ParallelUploader) Upload(ctx tcontext.TransferMetadata, config *DependencyTrackConfig, client *DependencyTrackClient, iter iterator.SBOMIterator) error {
 	logger.LogDebug(ctx.Context, "Uploading SBOMs to Dependency-Track in parallel mode")
 
 	sbomChan := make(chan *iterator.SBOM, 100)
@@ -124,7 +124,7 @@ func (u *ParallelUploader) Upload(ctx *tcontext.TransferMetadata, config *Depend
 	// multiple goroutines will read SBOMs from the iterator.
 	go func() {
 		for {
-			sbom, err := iter.Next(ctx.Context)
+			sbom, err := iter.Next(ctx)
 			if err == io.EOF {
 				logger.LogInfo(ctx.Context, "All SBOMs uploaded successfully, no more SBOMs left")
 				logger.LogInfo(ctx.Context, "Total SBOMs", "count", totalSBOMs)

--- a/pkg/target/folder/adapter.go
+++ b/pkg/target/folder/adapter.go
@@ -95,18 +95,18 @@ func (f *FolderAdapter) ParseAndValidateParams(cmd *cobra.Command) error {
 }
 
 // FetchSBOMs retrieves SBOMs lazily
-func (i *FolderAdapter) FetchSBOMs(ctx *tcontext.TransferMetadata) (iterator.SBOMIterator, error) {
+func (i *FolderAdapter) FetchSBOMs(ctx tcontext.TransferMetadata) (iterator.SBOMIterator, error) {
 	return nil, fmt.Errorf("Folder adapter does not support SBOM Fetching")
 }
 
 // UploadSBOMs writes SBOMs to the output folder
-func (f *FolderAdapter) UploadSBOMs(ctx *tcontext.TransferMetadata, iter iterator.SBOMIterator) error {
+func (f *FolderAdapter) UploadSBOMs(ctx tcontext.TransferMetadata, iter iterator.SBOMIterator) error {
 	logger.LogDebug(ctx.Context, "Starting SBOM upload", "mode", f.config.Settings.ProcessingMode)
 	return f.Uploader.Upload(ctx, f.config, iter)
 }
 
 // DryRun for Output Adapter: Simulates writing SBOMs to a folder
-func (f *FolderAdapter) DryRun(ctx *tcontext.TransferMetadata, iter iterator.SBOMIterator) error {
+func (f *FolderAdapter) DryRun(ctx tcontext.TransferMetadata, iter iterator.SBOMIterator) error {
 	reporter := NewFolderOutputReporter(f.config.FolderPath)
-	return reporter.DryRun(ctx.Context, iter)
+	return reporter.DryRun(ctx, iter)
 }

--- a/pkg/target/folder/reporter.go
+++ b/pkg/target/folder/reporter.go
@@ -15,7 +15,6 @@
 package folder
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -23,6 +22,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/interlynk-io/sbommv/pkg/iterator"
 	"github.com/interlynk-io/sbommv/pkg/logger"
+	"github.com/interlynk-io/sbommv/pkg/tcontext"
 )
 
 type FolderOutputReporter struct {
@@ -33,8 +33,8 @@ func NewFolderOutputReporter(folderPath string) *FolderOutputReporter {
 	return &FolderOutputReporter{folderPath: folderPath}
 }
 
-func (r *FolderOutputReporter) DryRun(ctx context.Context, iter iterator.SBOMIterator) error {
-	logger.LogDebug(ctx, "Dry-run mode: Displaying SBOMs for folder output")
+func (r *FolderOutputReporter) DryRun(ctx tcontext.TransferMetadata, iter iterator.SBOMIterator) error {
+	logger.LogDebug(ctx.Context, "Dry-run mode: Displaying SBOMs for folder output")
 	fmt.Println("\n📦 **Folder Output Adapter Dry-Run**")
 	sbomCount := 0
 
@@ -44,7 +44,7 @@ func (r *FolderOutputReporter) DryRun(ctx context.Context, iter iterator.SBOMIte
 			break
 		}
 		if err != nil {
-			logger.LogError(ctx, err, "Error retrieving SBOM from iterator")
+			logger.LogError(ctx.Context, err, "Error retrieving SBOM from iterator")
 			return err
 		}
 
@@ -63,6 +63,6 @@ func (r *FolderOutputReporter) DryRun(ctx context.Context, iter iterator.SBOMIte
 	}
 
 	fmt.Printf("\n📊 Total SBOMs to be stored: %d\n", sbomCount)
-	logger.LogDebug(ctx, "Dry-run completed", "total_sboms", sbomCount)
+	logger.LogDebug(ctx.Context, "Dry-run completed", "total_sboms", sbomCount)
 	return nil
 }

--- a/pkg/target/folder/uploader.go
+++ b/pkg/target/folder/uploader.go
@@ -28,7 +28,7 @@ import (
 )
 
 type SBOMUploader interface {
-	Upload(ctx *tcontext.TransferMetadata, config *FolderConfig, iter iterator.SBOMIterator) error
+	Upload(ctx tcontext.TransferMetadata, config *FolderConfig, iter iterator.SBOMIterator) error
 }
 
 var uploaderFactory = map[types.UploadMode]SBOMUploader{
@@ -38,17 +38,17 @@ var uploaderFactory = map[types.UploadMode]SBOMUploader{
 
 type SequentialUploader struct{}
 
-func (u *SequentialUploader) Upload(ctx *tcontext.TransferMetadata, config *FolderConfig, iter iterator.SBOMIterator) error {
+func (u *SequentialUploader) Upload(ctx tcontext.TransferMetadata, config *FolderConfig, iter iterator.SBOMIterator) error {
 	logger.LogDebug(ctx.Context, "Writing SBOMs sequentially", "folder", config.FolderPath)
 	totalSBOMs := 0
 	successfullyUploaded := 0
 
 	for {
-		sbom, err := iter.Next(ctx.Context)
+		sbom, err := iter.Next(ctx)
 		if err == io.EOF {
-			logger.LogInfo(ctx.Context, "All SBOMs uploaded successfully, no more SBOMs left")
+			logger.LogInfo(ctx.Context, "All SBOMs successfully saved to provided directory")
 			logger.LogInfo(ctx.Context, "Total SBOMs", "count", totalSBOMs)
-			logger.LogInfo(ctx.Context, "Successfully Uploaded", "count", successfullyUploaded)
+			logger.LogInfo(ctx.Context, "Successfully saved", "count", successfullyUploaded)
 			break
 		}
 		totalSBOMs++

--- a/pkg/target/interlynk/adapter.go
+++ b/pkg/target/interlynk/adapter.go
@@ -128,11 +128,11 @@ func (i *InterlynkAdapter) ParseAndValidateParams(cmd *cobra.Command) error {
 }
 
 // FetchSBOMs retrieves SBOMs lazily
-func (i *InterlynkAdapter) FetchSBOMs(ctx *tcontext.TransferMetadata) (iterator.SBOMIterator, error) {
+func (i *InterlynkAdapter) FetchSBOMs(ctx tcontext.TransferMetadata) (iterator.SBOMIterator, error) {
 	return nil, fmt.Errorf("Interlynk adapter does not support SBOM Fetching")
 }
 
-func (i *InterlynkAdapter) UploadSBOMs(ctx *tcontext.TransferMetadata, iterator iterator.SBOMIterator) error {
+func (i *InterlynkAdapter) UploadSBOMs(ctx tcontext.TransferMetadata, iterator iterator.SBOMIterator) error {
 	logger.LogDebug(ctx.Context, "Starting SBOM upload", "mode", i.settings.ProcessingMode)
 
 	if i.settings.ProcessingMode != "sequential" {
@@ -164,7 +164,7 @@ func (i *InterlynkAdapter) UploadSBOMs(ctx *tcontext.TransferMetadata, iterator 
 }
 
 // uploadSequential handles sequential SBOM processing and uploading
-func (i *InterlynkAdapter) uploadSequential(ctx *tcontext.TransferMetadata, sboms iterator.SBOMIterator) error {
+func (i *InterlynkAdapter) uploadSequential(ctx tcontext.TransferMetadata, sboms iterator.SBOMIterator) error {
 	logger.LogDebug(ctx.Context, "Uploading SBOMs in sequential mode")
 
 	// Initialize Interlynk API client
@@ -180,7 +180,7 @@ func (i *InterlynkAdapter) uploadSequential(ctx *tcontext.TransferMetadata, sbom
 	totalSBOMs := 0
 	successfullyUploaded := 0
 	for {
-		sbom, err := sboms.Next(ctx.Context)
+		sbom, err := sboms.Next(ctx)
 		if err == io.EOF {
 			logger.LogInfo(ctx.Context, "All SBOMs uploaded successfully, no more SBOMs left")
 			logger.LogInfo(ctx.Context, "Total SBOMs", "count", totalSBOMs)
@@ -221,7 +221,7 @@ func (i *InterlynkAdapter) uploadSequential(ctx *tcontext.TransferMetadata, sbom
 }
 
 // DryRunUpload simulates SBOM upload to Interlynk without actual data transfer.
-func (i *InterlynkAdapter) DryRun(ctx *tcontext.TransferMetadata, sbomIterator iterator.SBOMIterator) error {
+func (i *InterlynkAdapter) DryRun(ctx tcontext.TransferMetadata, sbomIterator iterator.SBOMIterator) error {
 	logger.LogDebug(ctx.Context, "🔄 Dry-Run Mode: Simulating Upload to Interlynk...")
 
 	// Step 1: Validate Interlynk Connection
@@ -239,7 +239,7 @@ func (i *InterlynkAdapter) DryRun(ctx *tcontext.TransferMetadata, sbomIterator i
 	uniqueFormats := make(map[string]struct{})
 
 	for {
-		sbom, err := sbomIterator.Next(ctx.Context)
+		sbom, err := sbomIterator.Next(ctx)
 		if err == io.EOF {
 			break
 		}

--- a/pkg/target/interlynk/client.go
+++ b/pkg/target/interlynk/client.go
@@ -91,7 +91,7 @@ func NewClient(config Config) *Client {
 	}
 }
 
-func (c *Client) FindOrCreateProjectGroup(ctx *tcontext.TransferMetadata, repoName string) (string, error) {
+func (c *Client) FindOrCreateProjectGroup(ctx tcontext.TransferMetadata, repoName string) (string, error) {
 	projectName := ""
 	if c.ProjectName != "" {
 		projectName = c.ProjectName
@@ -122,7 +122,7 @@ func (c *Client) FindOrCreateProjectGroup(ctx *tcontext.TransferMetadata, repoNa
 }
 
 // UploadSBOM uploads a single SBOM from memory to Interlynk
-func (c *Client) UploadSBOM(ctx *tcontext.TransferMetadata, projectID string, sbomData []byte) error {
+func (c *Client) UploadSBOM(ctx tcontext.TransferMetadata, projectID string, sbomData []byte) error {
 	if len(sbomData) == 0 {
 		return fmt.Errorf("SBOM data is empty")
 	}
@@ -137,7 +137,7 @@ func (c *Client) UploadSBOM(ctx *tcontext.TransferMetadata, projectID string, sb
 	return c.executeUploadRequest(ctx, req)
 }
 
-func (c *Client) createUploadRequest(ctx *tcontext.TransferMetadata, projectID string, sbomData []byte) (*http.Request, error) {
+func (c *Client) createUploadRequest(ctx tcontext.TransferMetadata, projectID string, sbomData []byte) (*http.Request, error) {
 	const uploadMutation = `
         mutation uploadSbom($doc: Upload!, $projectId: ID!) {
             sbomUpload(input: { doc: $doc, projectId: $projectId }) {
@@ -219,7 +219,7 @@ func writeJSONField(writer *multipart.Writer, fieldName string, data interface{}
 	return nil
 }
 
-func (c *Client) executeUploadRequest(ctx *tcontext.TransferMetadata, req *http.Request) error {
+func (c *Client) executeUploadRequest(ctx tcontext.TransferMetadata, req *http.Request) error {
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("sending request: %w", err)
@@ -261,7 +261,7 @@ func (c *Client) executeUploadRequest(ctx *tcontext.TransferMetadata, req *http.
 	return nil
 }
 
-func (c *Client) FindProjectGroup(ctx *tcontext.TransferMetadata, name string, env string) (string, error) {
+func (c *Client) FindProjectGroup(ctx tcontext.TransferMetadata, name string, env string) (string, error) {
 	const findProjectGroupMutation = `
 		query FindProjectGroup($search: String) {
 			  organization {
@@ -371,7 +371,7 @@ func (c *Client) FindProjectGroup(ctx *tcontext.TransferMetadata, name string, e
 }
 
 // CreateProjectGroup creates a new project group and returns the default project's ID
-func (c *Client) CreateProjectGroup(ctx *tcontext.TransferMetadata, name, env string) (string, error) {
+func (c *Client) CreateProjectGroup(ctx tcontext.TransferMetadata, name, env string) (string, error) {
 	const createProjectGroupMutation = `
         mutation CreateProjectGroup($name: String!, $desc: String, $enabled: Boolean) {
             projectGroupCreate(

--- a/pkg/types/mvtypes.go
+++ b/pkg/types/mvtypes.go
@@ -27,4 +27,7 @@ type Config struct {
 
 	// dry run mode
 	DryRun bool
+
+	// daemon mode
+	Daemon bool
 }


### PR DESCRIPTION
closes #59 

This PR add the following changes:
- It implements folder monitoring feature for the Folder input adapter, enabling real-time detection and uploading of SBOMs as they become available, using a daemon mode triggered by the `-d` flag.
- New Interface `MonitorAdapter` is added to differntiate adapter with monitoring capability an non-monitorig. All input adapters will be implementing it for now.
  - The `Monitor` method of  `MonitorAdapter` is invoked when `-d` flag is provided. If not provided then `FetchSBOMs` is invoked. 
  - FetchSBOMs represent to single time fetching of all SBOMs.
  - Whereas, `Monitor` method in `MonitorAdapter` interface, fetches SBOMs in real time, when any event is made.
- Folder Adapter implemented `Monitor` method to support real-time monitoring.
- Added `WatcherIterator` to store SBOM in real time. It recieves a SBOM when a newly SBOM is added to a folder or existing SBOM is modified. In bboth cases, the iterator recieves the SBOMs on a real time via channel. Whereas earlier `FolderIterator` used to store all SBOMs in one go, and that was fetched in a sequential or parallel manner. 
- Simialrly, these iterator are used while uploading SBOMs. The `FolderIterator` used to upload all SBOM until and unless list becomes exhausted i.e `EOF`, but `WatcherIterator`  doesn't close until and unless the channel is closed. And the channel closes on context cancellation or watcher error or `ctrl+c`.
-  Add methods to alteast implement for github adapter. For now, will return an error that github  doesn't support real-time monitoring.

Although I have tested for `folder` --> `interlynk`. it works perfectlly fine. The watcher is trigger in2 cases:
- when newly sbom is added
- when existing sbom is modifies.
In both case, they are feeded to channel, and then it is uploaded.

