### PR TITLE
save sbom to provided path inside of repo name under sub-path

### DIFF
--- a/pkg/target/folder/adapter.go
+++ b/pkg/target/folder/adapter.go
@@ -76,12 +76,12 @@ func (f *FolderAdapter) ParseAndValidateParams(cmd *cobra.Command) error {
 
 	// Validate required flags
 	if len(missingFlags) > 0 {
-		return fmt.Errorf("missing input adapter required flags: %v\n\nUse 'sbommv transfer --help' for usage details.", missingFlags)
+		return fmt.Errorf("missing output adapter required flags: %v\n\nUse 'sbommv transfer --help' for usage details.", missingFlags)
 	}
 
 	// Validate incorrect flag usage
 	if len(invalidFlags) > 0 {
-		return fmt.Errorf("invalid input adapter flag usage:\n %s\n\nUse 'sbommv transfer --help' for correct usage.", strings.Join(invalidFlags, "\n "))
+		return fmt.Errorf("invalid output adapter flag usage:\n %s\n\nUse 'sbommv transfer --help' for correct usage.", strings.Join(invalidFlags, "\n "))
 	}
 
 	cfg := FolderConfig{

--- a/pkg/target/folder/uploader.go
+++ b/pkg/target/folder/uploader.go
@@ -46,9 +46,9 @@ func (u *SequentialUploader) Upload(ctx *tcontext.TransferMetadata, config *Fold
 	for {
 		sbom, err := iter.Next(ctx.Context)
 		if err == io.EOF {
-			logger.LogInfo(ctx.Context, "All SBOMs uploaded successfully, no more SBOMs left")
+			logger.LogInfo(ctx.Context, "All SBOMs successfully saved to provided directory")
 			logger.LogInfo(ctx.Context, "Total SBOMs", "count", totalSBOMs)
-			logger.LogInfo(ctx.Context, "Successfully Uploaded", "count", successfullyUploaded)
+			logger.LogInfo(ctx.Context, "Successfully saved", "count", successfullyUploaded)
 			break
 		}
 		totalSBOMs++
@@ -57,11 +57,11 @@ func (u *SequentialUploader) Upload(ctx *tcontext.TransferMetadata, config *Fold
 			return err
 		}
 
-		namespace := filepath.Base(sbom.Namespace)
-		if namespace == "" {
-			namespace = fmt.Sprintf("sbom_%s.json", uuid.New().String())
+		outputDir := config.FolderPath
+		if outputDir == "" {
+			outputDir = sbom.Namespace
 		}
-		outputDir := filepath.Join(config.FolderPath, namespace)
+
 		if err := os.MkdirAll(outputDir, 0o755); err != nil {
 			logger.LogError(ctx.Context, err, "Failed to create folder", "path", outputDir)
 			return err


### PR DESCRIPTION
This PR adds the following changes:
- Saves the SBOMs under provided path, instead of dir with repo name. And this is a sub-dir of provided path.