### PR TITLE
Fix/project name with version

### DIFF
--- a/pkg/source/folder/fetcher.go
+++ b/pkg/source/folder/fetcher.go
@@ -52,12 +52,15 @@ func (f *SequentialFetcher) Fetch(ctx tcontext.TransferMetadata, config *FolderC
 		if info.IsDir() && !config.Recursive && path != config.FolderPath {
 			return filepath.SkipDir
 		}
-		if source.IsSBOMFile(path) {
-			content, err := os.ReadFile(path)
-			if err != nil {
-				logger.LogError(ctx.Context, err, "Failed to read SBOM", "path", path)
-				return nil
-			}
+
+		content, err := os.ReadFile(path)
+		if err != nil {
+			logger.LogError(ctx.Context, err, "Failed to read SBOM", "path", path)
+			return nil
+		}
+
+		if source.IsSBOMFile(content) {
+
 			// projectName, path := getTopLevelDirAndFile(config.FolderPath, path)
 			primaryComp, err := sbom.ExtractPrimaryComponentName(content)
 			if err != nil {
@@ -118,13 +121,13 @@ func (f *ParallelFetcher) Fetch(ctx tcontext.TransferMetadata, config *FolderCon
 					continue
 				}
 
-				if !source.IsSBOMFile(path) {
-					continue
-				}
-
 				content, err := os.ReadFile(path)
 				if err != nil {
 					logger.LogError(ctx.Context, err, "Failed to read SBOM", "path", path)
+					continue
+				}
+
+				if !source.IsSBOMFile(content) {
 					continue
 				}
 

--- a/pkg/source/folder/fetcher.go
+++ b/pkg/source/folder/fetcher.go
@@ -48,8 +48,13 @@ func (f *SequentialFetcher) Fetch(ctx tcontext.TransferMetadata, config *FolderC
 			logger.LogError(ctx.Context, err, "Error accessing file", "path", path)
 			return nil
 		}
-		if info.IsDir() && !config.Recursive && path != config.FolderPath {
-			return filepath.SkipDir
+
+		if info.IsDir() {
+			// Skip subdirectories if not recursive
+			if !config.Recursive && path != config.FolderPath {
+				return filepath.SkipDir
+			}
+			return nil
 		}
 
 		content, err := os.ReadFile(path)

--- a/pkg/source/folder/fetcher.go
+++ b/pkg/source/folder/fetcher.go
@@ -64,16 +64,19 @@ func (f *SequentialFetcher) Fetch(ctx tcontext.TransferMetadata, config *FolderC
 				logger.LogDebug(ctx.Context, "Failed to parse SBOM for primary component", "path", path, "error", err)
 			}
 
-			logger.LogDebug(ctx.Context, "Primary Component", "value", primaryComp)
+			primaryCompName, primaryCompVersion := primaryComp.Name, primaryComp.Version
+
+			logger.LogDebug(ctx.Context, "Primary Component", "name", primaryCompName, "version", primaryCompVersion)
 
 			fileName := getFilePath(config.FolderPath, path)
 			sbomList = append(sbomList, &iterator.SBOM{
 				Data:      content,
 				Path:      fileName,
-				Namespace: primaryComp,
+				Namespace: primaryCompName,
+				Version:   primaryCompVersion,
 			})
 		} else {
-			logger.LogDebug(ctx.Context, "Skipping non-SBOM file", "path", path)
+			logger.LogDebug(ctx.Context, "Skipping non-SBOM file", "path", getFilePath(config.FolderPath, path))
 		}
 		return nil
 	})
@@ -130,6 +133,8 @@ func (f *ParallelFetcher) Fetch(ctx tcontext.TransferMetadata, config *FolderCon
 				if err != nil {
 					logger.LogDebug(ctx.Context, "Failed to parse SBOM for primary component", "path", path, "error", err)
 				}
+				primaryCompName, primaryCompVersion := primaryComp.Name, primaryComp.Version
+				logger.LogDebug(ctx.Context, "Primary Component", "name", primaryCompName, "version", primaryCompVersion)
 
 				//  get a relative file path.
 				fileName := getFilePath(config.FolderPath, path)
@@ -138,7 +143,8 @@ func (f *ParallelFetcher) Fetch(ctx tcontext.TransferMetadata, config *FolderCon
 				sbomList = append(sbomList, &iterator.SBOM{
 					Data:      content,
 					Path:      fileName,
-					Namespace: primaryComp,
+					Namespace: primaryCompName,
+					Version:   primaryCompVersion,
 				})
 				mu.Unlock()
 			}

--- a/pkg/source/folder/retrieve.go
+++ b/pkg/source/folder/retrieve.go
@@ -1,3 +1,18 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -------------------------------------------------------------------------
+
 package folder
 
 import (

--- a/pkg/source/folder/retrieve.go
+++ b/pkg/source/folder/retrieve.go
@@ -1,0 +1,37 @@
+package folder
+
+import (
+	"path/filepath"
+
+	"github.com/interlynk-io/sbommv/pkg/logger"
+	"github.com/interlynk-io/sbommv/pkg/sbom"
+	"github.com/interlynk-io/sbommv/pkg/source"
+	"github.com/interlynk-io/sbommv/pkg/tcontext"
+)
+
+func getProjectNameAndVersion(ctx tcontext.TransferMetadata, fileName string, content []byte) (string, string) {
+	var projectName, projectVersion string
+
+	if source.IsSBOMJSONFormat(content) {
+
+		logger.LogDebug(ctx.Context, "SBOM is in JSON format", "path", fileName)
+		primaryComp, err := sbom.ExtractPrimaryComponentName(content)
+		if err != nil {
+			// when a JSON SBOM has empty primary comp and version, use the file name as project name
+			projectName = filepath.Base(fileName)
+			projectName = projectName[:len(projectName)-len(filepath.Ext(projectName))]
+			projectVersion = "latest"
+			logger.LogDebug(ctx.Context, "Failed to parse SBOM for primary component from JSON format SBOM", "path", fileName, "error", err)
+		} else {
+			projectName, projectVersion = primaryComp.Name, primaryComp.Version
+		}
+	} else {
+		logger.LogDebug(ctx.Context, "SBOM is not in JSON format", "path", fileName)
+		projectName = filepath.Base(fileName)
+		projectName = projectName[:len(projectName)-len(filepath.Ext(projectName))]
+
+		projectVersion = "latest"
+	}
+
+	return projectName, projectVersion
+}

--- a/pkg/source/folder/watcher.go
+++ b/pkg/source/folder/watcher.go
@@ -85,12 +85,13 @@ func (f *WatcherFetcher) Fetch(ctx tcontext.TransferMetadata, config *FolderConf
 					logger.LogInfo(ctx.Context, "Event Triggered", "name", event)
 				}
 
-				if event.Op&(fsnotify.Write) != 0 && source.IsSBOMFile(event.Name) {
-					content, err := os.ReadFile(event.Name)
-					if err != nil {
-						logger.LogError(ctx.Context, err, "Failed to read SBOM", "path", event.Name)
-						continue
-					}
+				content, err := os.ReadFile(event.Name)
+				if err != nil {
+					logger.LogError(ctx.Context, err, "Failed to read SBOM", "path", event.Name)
+					continue
+				}
+
+				if event.Op&(fsnotify.Write) != 0 && source.IsSBOMFile(content) {
 
 					primaryComp, err := sbom.ExtractPrimaryComponentName(content)
 					if err != nil {

--- a/pkg/source/folder/watcher.go
+++ b/pkg/source/folder/watcher.go
@@ -97,12 +97,16 @@ func (f *WatcherFetcher) Fetch(ctx tcontext.TransferMetadata, config *FolderConf
 						logger.LogDebug(ctx.Context, "Failed to parse SBOM for primary component", "path", event.Name, "error", err)
 					}
 
+					primaryCompName, primaryCompVersion := primaryComp.Name, primaryComp.Version
+					logger.LogDebug(ctx.Context, "Primary Component", "name", primaryCompName, "version", primaryCompVersion)
+
 					fileName := getFilePath(config.FolderPath, event.Name)
 					logger.LogDebug(ctx.Context, "Detected SBOM", "file", fileName)
 					sbomChan <- &iterator.SBOM{
 						Data:      content,
 						Path:      fileName,
-						Namespace: primaryComp,
+						Namespace: primaryCompName,
+						Version:   primaryCompVersion,
 					}
 				}
 			case err, ok := <-watcher.Errors:

--- a/pkg/source/utils.go
+++ b/pkg/source/utils.go
@@ -49,6 +49,21 @@ func IsSBOMFile(content []byte) bool {
 	return true
 }
 
+func IsSBOMJSONFormat(data []byte) bool {
+	reader := bytes.NewReader(data)
+
+	_, format, err := detect.Detect(reader)
+	if err != nil {
+		return false
+	}
+
+	if format == detect.FileFormatJSON {
+		return true
+	}
+
+	return false
+}
+
 // DetectSBOMsFile simply detects files names and on the basis of possible patterns of SBOM files it retreives them.
 func DetectSBOMsFile(name string) bool {
 	name = strings.ToLower(name)

--- a/pkg/target/dependencytrack/adapter.go
+++ b/pkg/target/dependencytrack/adapter.go
@@ -47,7 +47,7 @@ type DependencyTrackAdapter struct {
 func (d *DependencyTrackAdapter) AddCommandParams(cmd *cobra.Command) {
 	cmd.Flags().String("out-dtrack-url", "", "Dependency Track API URL")
 	cmd.Flags().String("out-dtrack-project-name", "", "Project name to upload SBOMs to")
-	cmd.Flags().String("out-dtrack-project-version", "latest", "Project version (default: latest)")
+	cmd.Flags().String("out-dtrack-project-version", "", "Project version (default: latest)")
 }
 
 // ParseAndValidateParams validates the Dependency-Track adapter params
@@ -149,6 +149,6 @@ func (d *DependencyTrackAdapter) UploadSBOMs(ctx tcontext.TransferMetadata, iter
 }
 
 func (d *DependencyTrackAdapter) DryRun(ctx tcontext.TransferMetadata, iter iterator.SBOMIterator) error {
-	reporter := NewDependencyTrackReporter(d.Config.APIURL, d.Config.ProjectName)
+	reporter := NewDependencyTrackReporter(d.Config.APIURL, d.Config.ProjectName, d.Config.ProjectVersion)
 	return reporter.DryRun(ctx, iter)
 }

--- a/pkg/target/dependencytrack/client.go
+++ b/pkg/target/dependencytrack/client.go
@@ -104,7 +104,7 @@ func (c *DependencyTrackClient) FindOrCreateProject(ctx tcontext.TransferMetadat
 		logger.LogDebug(ctx.Context, "Project already exists, therefor it wouldn't create a new", "project", projectName, "uuid", uuid)
 		return uuid, nil
 	}
-	logger.LogDebug(ctx.Context, "New project will be created", "project", projectName, "version", projectVersion)
+	logger.LogDebug(ctx.Context, "New project will be created", "name", projectName, "version", projectVersion)
 
 	// create project using project name and project version
 	return c.CreateProject(ctx, projectName, projectVersion)

--- a/pkg/target/interlynk/utils.go
+++ b/pkg/target/interlynk/utils.go
@@ -20,6 +20,9 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/interlynk-io/sbommv/pkg/logger"
+	"github.com/interlynk-io/sbommv/pkg/tcontext"
 )
 
 // ValidateInterlynkConnection chesks whether Interlynk ssytem is up and running
@@ -76,4 +79,38 @@ func formatSetToString(formatSet map[string]struct{}) string {
 		formats = append(formats, format)
 	}
 	return strings.Join(formats, ", ")
+}
+
+func getProjectName(ctx tcontext.TransferMetadata, providedProjectName string, namespace string) (string, error) {
+	if providedProjectName == "" && namespace == "" {
+		return "", fmt.Errorf("no project name specified and SBOM namespace is empty")
+	}
+
+	var projectName string
+	if providedProjectName != "" {
+		projectName = providedProjectName
+		logger.LogDebug(ctx.Context, "Project Name is provided by the user", "name", projectName)
+	} else {
+		projectName = namespace
+		logger.LogDebug(ctx.Context, "Project Name as sbom.Namespace will be used", "sbom.Namespace", namespace)
+	}
+
+	return projectName, nil
+}
+
+func getProjectVersion(ctx tcontext.TransferMetadata, providedProjectVersion string, version string) string {
+	var projectVersion string
+	if providedProjectVersion == "" && version == "" {
+		projectVersion = "latest"
+	}
+
+	if providedProjectVersion != "" {
+		projectVersion = providedProjectVersion
+		logger.LogDebug(ctx.Context, "Project Version is provided by the user", "version", projectVersion)
+	} else {
+		projectVersion = version
+		logger.LogDebug(ctx.Context, "Project Version as sbom.Version will be used", "sbom.Version", projectVersion)
+	}
+
+	return projectVersion
 }


### PR DESCRIPTION
This PR adds the following changes:
- Project Name for non-JSON SBOM will be their filename
- Project Name for JSON SBOM doesn't have primary comp details would be filename
- Project Name will be finally equal to Name + Version.
- Validate path: make sure it doesn't read dir instead of file