### PR TITLE
fix api method mising updating repourl

### DIFF
--- a/pkg/source/github/client.go
+++ b/pkg/source/github/client.go
@@ -360,6 +360,8 @@ func (c *Client) FetchSBOMFromAPI(ctx tcontext.TransferMetadata) ([]byte, error)
 		return nil, fmt.Errorf("parsing GitHub URL: %w", err)
 	}
 
+	logger.LogDebug(ctx.Context, "Fetching SBOM Details", "repository", repo, "owner", owner, "repo_url", c.RepoURL)
+
 	// Construct the API URL for the SBOM export
 	url := fmt.Sprintf("%s/%s", c.BaseURL, fmt.Sprintf(githubSBOMEndpoint, owner, repo))
 	logger.LogDebug(ctx.Context, "Fetching SBOM via GitHub API", "url", url)

--- a/pkg/target/dependencytrack/uploader.go
+++ b/pkg/target/dependencytrack/uploader.go
@@ -111,6 +111,7 @@ func (u *ParallelUploader) Upload(ctx tcontext.TransferMetadata, config *Depende
 	sbomChan := make(chan *iterator.SBOM, 100)
 	totalSBOMs := 0
 	successfullyUploaded := 0
+
 	// multiple goroutines will read SBOMs from the iterator.
 	go func() {
 		for {
@@ -175,7 +176,7 @@ func (u *ParallelUploader) Upload(ctx tcontext.TransferMetadata, config *Depende
 
 	// wait for all workers to complete.
 	wg.Wait()
-	logger.LogInfo(ctx.Context, "Successfully Uploaded", "count", successfullyUploaded)
+	logger.LogInfo(ctx.Context, "Successfully Uploaded", "Total count", totalSBOMs, "Success", successfullyUploaded, "Failed", totalSBOMs-successfullyUploaded)
 	return nil
 }
 


### PR DESCRIPTION
This PR adds the following changes:
- It fixes the fetching of SBOM via sequential method as it was lacking updating of repourl.
- It  also fixes the fetching of SBOM via parallel method as it was lacking updating of handling of errors, as a result it appends repo with no sboms along with an error.