### PR TITLE
fix tool method partially

### DIFF
--- a/pkg/engine/transfer.go
+++ b/pkg/engine/transfer.go
@@ -145,15 +145,13 @@ func sbomProcessing(ctx tcontext.TransferMetadata, config types.Config, sbomIter
 
 	// convert sbom to cdx for DTrack adapter only
 	if types.AdapterType(config.DestinationAdapter) == types.DtrackAdapterType {
-		logger.LogDebug(ctx.Context, "Adapter eligible for conversion layer", "adapter type", config.DestinationAdapter)
 
-		logger.LogDebug(ctx.Context, "SBOM conversion will take place")
+		logger.LogDebug(ctx.Context, "Adapter is eligible for SBOM conversion", "adapter type", config.DestinationAdapter)
 		// convertedSBOMs := sbomConversion(sbomIterator, ctx)
 		return iterator.NewConvertedIterator(sbomIterator, sbom.FormatSpecCycloneDX)
 		// return iterator.NewMemoryIterator(convertedSBOMs)
 	} else {
-		logger.LogDebug(ctx.Context, "Adapter accept both SPDX and CDX SBOM, therefore doesn't require conversion layer", "adapter type", config.DestinationAdapter)
-		logger.LogDebug(ctx.Context, "SBOM conversion will not take place")
+		logger.LogDebug(ctx.Context, "Adapter is not eligible for SBOM conversion", "adapter type", config.DestinationAdapter)
 		return sbomIterator
 	}
 }

--- a/pkg/source/github/client.go
+++ b/pkg/source/github/client.go
@@ -475,7 +475,7 @@ func (c *Client) GetAllRepositories(ctx tcontext.TransferMetadata) ([]string, er
 		return nil, fmt.Errorf("no repositories found for organization %s", c.Owner)
 	}
 
-	logger.LogDebug(ctx.Context, "Total number of repos", "count", len(repos), "in organization", c.Owner)
+	logger.LogDebug(ctx.Context, "Total available repos in an organization", "count", len(repos), "in organization", c.Owner)
 
 	return repoNames, nil
 }

--- a/pkg/target/dependencytrack/uploader.go
+++ b/pkg/target/dependencytrack/uploader.go
@@ -39,7 +39,7 @@ func NewSequentialUploader() *SequentialUploader {
 }
 
 func (u *SequentialUploader) Upload(ctx tcontext.TransferMetadata, config *DependencyTrackConfig, client *DependencyTrackClient, iter iterator.SBOMIterator) error {
-	logger.LogDebug(ctx.Context, "Uploading SBOMs to Dependency-Track sequentially")
+	logger.LogDebug(ctx.Context, "Initializing SBOMs uploading to Dependency-Track sequentially")
 
 	totalSBOMs := 0
 	successfullyUploaded := 0
@@ -77,21 +77,21 @@ func (u *SequentialUploader) Upload(ctx tcontext.TransferMetadata, config *Depen
 			u.createdProjects[finalProjectName] = true
 		}
 
-		logger.LogDebug(ctx.Context, "Initializing uploading SBOM file", "file", sbom.Path)
+		logger.LogDebug(ctx.Context, "Initializing uploading SBOM content", "size", len(sbom.Data), "file", sbom.Path)
 
 		err = client.UploadSBOM(ctx, finalProjectName, projectVersion, sbom.Data)
 		if err != nil {
-			logger.LogDebug(ctx.Context, "Upload Failed for", "project", finalProjectName, "file", sbom.Path, "error", err)
+			logger.LogDebug(ctx.Context, "Upload Failed for", "project", finalProjectName, "size", len(sbom.Data), "file", sbom.Path, "error", err)
 			continue
 		}
 		successfullyUploaded++
-		logger.LogDebug(ctx.Context, "Successfully uploaded SBOM file", "file", sbom.Path)
+		logger.LogDebug(ctx.Context, "Successfully uploaded SBOM file", "size", len(sbom.Data), "file", sbom.Path)
 	}
 	logger.LogInfo(ctx.Context, "Successfully Uploaded", "Total count", totalSBOMs, "Success", successfullyUploaded, "Failed", totalSBOMs-successfullyUploaded)
 	return nil
 }
 
-// // ParallelUploader uploads SBOMs to Dependency-Track concurrently.
+// ParallelUploader uploads SBOMs to Dependency-Track concurrently.
 type ParallelUploader struct {
 	createdProjects map[string]bool
 	mu              sync.Mutex // Protects access to createdProjects.
@@ -106,7 +106,7 @@ func NewParallelUploader() *ParallelUploader {
 
 // Upload implements the SBOMUploader interface for ParallelUploader.
 func (u *ParallelUploader) Upload(ctx tcontext.TransferMetadata, config *DependencyTrackConfig, client *DependencyTrackClient, iter iterator.SBOMIterator) error {
-	logger.LogDebug(ctx.Context, "Uploading SBOMs to Dependency-Track in parallel mode")
+	logger.LogDebug(ctx.Context, "Initializing SBOMs uploading to Dependency-Track parallely")
 
 	sbomChan := make(chan *iterator.SBOM, 100)
 	totalSBOMs := 0


### PR DESCRIPTION
This PR adds the following changes:
- fixed tool method partially for now.
  -  if  a repo supports SBOM generation, then it works perfectlly
  - byt if you feed repos like "docs", or some "scripts" , or "helpm charts" kind of repos, it does't generate SBOM, and upload zero components, although there are list of other repos which supports SBOM generation. For example: generate SBOMs for all repos of Interlynk