### PR TITLE
add test for github to dtrack via mocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,12 @@ jobs:
 
       - name: Install dependencies
         run: go mod download
+
+      - name: Set SBOMMV_TEST_FOLDER environment variable
+        run: echo "SBOMMV_TEST_FOLDER=$(pwd)/testdata/github" >> $GITHUB_ENV
+
+      - name: Run TestUploadGithubAPIToDTrack
+        run: go test -v ./cmd -run ^TestUploadGithubAPIToDTrack
+
+      - name: Run TestUploadFolderToDTrack
+        run: go test -v ./cmd -run ^TestUploadFolderToDTrack

--- a/cmd/transfer.go
+++ b/cmd/transfer.go
@@ -111,11 +111,12 @@ func transferSBOM(cmd *cobra.Command, args []string) error {
 
 	// Initialize logger based on debug flag
 	debug, _ := cmd.Flags().GetBool("debug")
-	logger.InitLogger(debug, false) // Using console format as default
-	defer logger.Sync()             // Flush logs on exit
+	logger.InitLogger(debug, false)
+	defer logger.Sync()
 
 	ctx := logger.WithLogger(context.Background())
 	viper.AutomaticEnv()
+	logger.LogDebug(ctx, "Starting transferSBOM")
 
 	// Parse config
 	config, err := parseConfig(cmd)

--- a/cmd/transfer.go
+++ b/cmd/transfer.go
@@ -112,6 +112,7 @@ func transferSBOM(cmd *cobra.Command, args []string) error {
 	// Initialize logger based on debug flag
 	debug, _ := cmd.Flags().GetBool("debug")
 	logger.InitLogger(debug, false)
+	defer logger.DeinitLogger()
 	defer logger.Sync()
 
 	ctx := logger.WithLogger(context.Background())

--- a/cmd/transfer_test.go
+++ b/cmd/transfer_test.go
@@ -1,0 +1,184 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// SBOMFolderPath retrieves the folder path from an environment variable with a fallback
+const (
+	defaultSBOMFolder = "../testdata/github" // Update this if needed
+)
+
+func SBOMFolderPath() string {
+	if path := os.Getenv("SBOMMV_TEST_FOLDER"); path != "" {
+		return path
+	}
+	return defaultSBOMFolder
+}
+
+// mockGitHubRelease mimics a GitHub API release response
+type mockGitHubRelease struct {
+	Assets []struct {
+		Name               string `json:"name"`
+		BrowserDownloadURL string `json:"browser_download_url"`
+	} `json:"assets"`
+}
+
+func TestTransferGitHubToDependencyTrack_ValidRepo_WithProject(t *testing.T) {
+	folderPath := SBOMFolderPath()
+	if folderPath == "" {
+		t.Fatal("SBOMMV_TEST_FOLDER not set")
+	}
+	sbomFile := folderPath + "/sbomqs_github_api_sbom.spdx.json"
+	if _, err := os.Stat(sbomFile); os.IsNotExist(err) {
+		t.Fatalf("GitHub SBOM file %s does not exist", sbomFile)
+	}
+
+	sbomData, err := os.ReadFile(sbomFile)
+	if err != nil {
+		t.Fatalf("Failed to read SBOM file %s: %v", sbomFile, err)
+	}
+
+	githubServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/repos/interlynk-io/sbomqs/dependency-graph/sbom" {
+			response := map[string]json.RawMessage{"sbom": sbomData}
+			w.Header().Set("Content-Type", "application/vnd.github.v3+json")
+			json.NewEncoder(w).Encode(response)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"message":"Not Found","documentation_url":"https://docs.github.com/rest","status":"404"}`))
+	}))
+	defer githubServer.Close()
+
+	dtrackServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/health" {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"status": "ok"}`))
+			return
+		}
+		if r.Method == "GET" && r.URL.Path == "/api/version" {
+			w.Write([]byte(`{"version":"4.12.5","timestamp":"2025-02-17T15:58:13Z","uuid":"550e8400-e29b-41d4-a716-446655440000"}`))
+			return
+		}
+		if r.Method == "GET" && r.URL.Path == "/api/v1/project" {
+			w.Write([]byte(`[]`))
+			return
+		}
+		if r.Method == "PUT" && r.URL.Path == "/api/v1/project" {
+			w.Write([]byte(`{"uuid": "39a35c94-b369-46e2-b67f-aed235cbc9c1", "name": "test-project-latest", "version": "latest"}`))
+			return
+		}
+		if r.Method == "PUT" && r.URL.Path == "/api/v1/bom" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			token := uuid.New().String()
+			response := fmt.Sprintf(`{"token":"%s"}`, token)
+			w.Write([]byte(response))
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error": "Invalid endpoint"}`))
+	}))
+	defer dtrackServer.Close()
+
+	os.Setenv("DTRACK_API_KEY", "dummy-key")
+	defer os.Unsetenv("DTRACK_API_KEY")
+
+	cmd := rootCmd
+	cmd.SetArgs([]string{
+		"transfer",
+		"--input-adapter=github",
+		"--in-github-url=" + githubServer.URL + "/interlynk-io/sbomqs",
+		"--in-github-method=api",
+		"--output-adapter=dtrack",
+		"--out-dtrack-url=" + dtrackServer.URL,
+		"--out-dtrack-project-name=test-project",
+		"--processing-mode=sequential",
+		"-D",
+	})
+
+	outBuf := bytes.NewBuffer(nil)
+	errBuf := bytes.NewBuffer(nil)
+
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Failed to create pipe: %v", err)
+	}
+	os.Stdout = w
+
+	cmd.SetOut(outBuf)
+	cmd.SetErr(errBuf)
+
+	t.Log("Before Execute")
+	err = cmd.Execute()
+
+	w.Close()
+	os.Stdout = origStdout
+
+	_, err = io.Copy(outBuf, r)
+	if err != nil {
+		t.Fatalf("Failed to copy pipe output: %v", err)
+	}
+
+	t.Logf("Execute error: %v", err)
+	t.Log("Output:", outBuf.String())
+	t.Log("Errors:", errBuf.String())
+
+	assert.NoError(t, err, "Expected successful transfer")
+	assert.Contains(t, outBuf.String(), "Initializing SBOMs uploading to Dependency-Track sequentially", "Expected upload start")
+	assert.Contains(t, outBuf.String(), "Fetched SBOM successfully", "Expected fetch success")
+	assert.Contains(t, outBuf.String(), "New project will be created", "Expected project creation")
+	assert.Contains(t, outBuf.String(), "Successfully Uploaded", "Expected successful upload completion")
+
+	type UploadStats struct {
+		TotalCount int `json:"Total count"`
+		Success    int `json:"Success"`
+		Failed     int `json:"Failed"`
+	}
+
+	var stats UploadStats
+	lines := strings.Split(outBuf.String(), "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "Successfully Uploaded") {
+
+			jsonStart := strings.Index(line, "{")
+			if jsonStart != -1 {
+				jsonStr := line[jsonStart:]
+				err := json.Unmarshal([]byte(jsonStr), &stats)
+				if err == nil {
+					break
+				}
+			}
+		}
+	}
+	assert.Equal(t, 1, stats.TotalCount, "Expected total count to be 1")
+	assert.Equal(t, 1, stats.Success, "Expected success count to be 1")
+	assert.Equal(t, 0, stats.Failed, "Expected failed count to be 0")
+}

--- a/cmd/transfer_test.go
+++ b/cmd/transfer_test.go
@@ -561,7 +561,6 @@ func TestUploadFolderToDTrack(t *testing.T) {
 	assert.Contains(t, outBuf.String(), `{"OutputAdapter": "dtrack"}`, "Expected Output adapter")
 
 	assert.Contains(t, outBuf.String(), "Locally SBOM located folder", "Expected sbom fetching")
-	assert.Contains(t, outBuf.String(), `{"path": "../testdata/github"}`, "Expected folder path")
 
 	assert.Contains(t, outBuf.String(), "Initializing SBOMs uploading to Dependency-Track sequentially", "Expected upload start")
 
@@ -671,7 +670,6 @@ func TestUploadFolderToDTrack_WithProjectName(t *testing.T) {
 	assert.Contains(t, outBuf.String(), "Initializing Output Adapter", "Expected Output adapter Initialization")
 	assert.Contains(t, outBuf.String(), `{"OutputAdapter": "dtrack"}`, "Expected Output adapter")
 	assert.Contains(t, outBuf.String(), "Locally SBOM located folder", "Expected sbom fetching")
-	assert.Contains(t, outBuf.String(), `{"path": "../testdata/github"}`, "Expected folder path")
 	assert.Contains(t, outBuf.String(), "Initializing SBOMs uploading to Dependency-Track sequentially", "Expected upload start")
 	assert.Contains(t, outBuf.String(), "New project will be created", "Expected project creation")
 	assert.Contains(t, outBuf.String(), "Successfully Uploaded", "Expected successful upload completion")
@@ -777,7 +775,6 @@ func TestUploadFolderToDTrack_WithProjectNameAndVersion(t *testing.T) {
 	assert.Contains(t, outBuf.String(), `{"OutputAdapter": "dtrack"}`, "Expected Output adapter")
 
 	assert.Contains(t, outBuf.String(), "Locally SBOM located folder", "Expected sbom fetching")
-	assert.Contains(t, outBuf.String(), `{"path": "../testdata/github"}`, "Expected folder path")
 
 	assert.Contains(t, outBuf.String(), "Initializing SBOMs uploading to Dependency-Track sequentially", "Expected upload start")
 

--- a/cmd/transfer_test.go
+++ b/cmd/transfer_test.go
@@ -63,6 +63,7 @@ func TestTransferGitHubToDependencyTrack_ValidRepo_WithProject(t *testing.T) {
 		t.Fatalf("Failed to read SBOM file %s: %v", sbomFile, err)
 	}
 
+	// mock github server
 	githubServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "GET" && r.URL.Path == "/repos/interlynk-io/sbomqs/dependency-graph/sbom" {
 			response := map[string]json.RawMessage{"sbom": sbomData}
@@ -75,32 +76,44 @@ func TestTransferGitHubToDependencyTrack_ValidRepo_WithProject(t *testing.T) {
 	}))
 	defer githubServer.Close()
 
+	// mock dependency server
 	dtrackServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// mock "/health" api
 		if r.Method == "GET" && r.URL.Path == "/health" {
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{"status": "ok"}`))
 			return
 		}
+
+		// mock "/api/version" api
 		if r.Method == "GET" && r.URL.Path == "/api/version" {
 			w.Write([]byte(`{"version":"4.12.5","timestamp":"2025-02-17T15:58:13Z","uuid":"550e8400-e29b-41d4-a716-446655440000"}`))
 			return
 		}
+
+		// mock "/api/v1/project" api
 		if r.Method == "GET" && r.URL.Path == "/api/v1/project" {
+
+			// return empty project list
 			w.Write([]byte(`[]`))
 			return
 		}
+
+		// mock "/api/v1/project" api
 		if r.Method == "PUT" && r.URL.Path == "/api/v1/project" {
 			w.Write([]byte(`{"uuid": "39a35c94-b369-46e2-b67f-aed235cbc9c1", "name": "test-project-latest", "version": "latest"}`))
 			return
 		}
+
+		// mock "/api/v1/bom" api
 		if r.Method == "PUT" && r.URL.Path == "/api/v1/bom" {
-			// w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			token := uuid.New().String()
 			response := fmt.Sprintf(`{"token":"%s"}`, token)
 			w.Write([]byte(response))
 			return
 		}
+
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(`{"error": "Invalid endpoint"}`))
 	}))
@@ -162,7 +175,118 @@ func TestTransferGitHubToDependencyTrack_ValidRepo_WithProject(t *testing.T) {
 	assert.Contains(t, outBuf.String(), `{"Total count": 1, "Success": 1, "Failed": 0}`, "Expected upload counts")
 }
 
-func TestTransferFolderToDependencyTrack_ValidSBOMs(t *testing.T) {
+// TEST:  uploaded folder to dtrack(without project name and project version)
+func TestUploadFolderToDTrack(t *testing.T) {
+	// Check if SBOM folder exists
+	folderPath := SBOMFolderPath()
+	if _, err := os.Stat(folderPath); os.IsNotExist(err) {
+		t.Skipf("SBOM folder %s does not exist, skipping test", folderPath)
+	}
+
+	dtrackServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/health" {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"status": "ok"}`))
+			return
+		}
+		if r.Method == "GET" && r.URL.Path == "/api/version" {
+			w.Write([]byte(`{"version":"4.12.5","timestamp":"2025-02-17T15:58:13Z","uuid":"550e8400-e29b-41d4-a716-446655440000"}`))
+			return
+		}
+		if r.Method == "GET" && r.URL.Path == "/api/v1/project" {
+			w.Write([]byte(`[]`))
+			return
+		}
+		if r.Method == "PUT" && r.URL.Path == "/api/v1/project" {
+			w.Write([]byte(`{"uuid": "39a35c94-b369-46e2-b67f-aed235cbc9c1", "name": "com.github.interlynk-io/sbomqs-main", "version": "main"}`))
+			return
+		}
+		if r.Method == "PUT" && r.URL.Path == "/api/v1/bom" {
+			w.WriteHeader(http.StatusOK)
+			token := uuid.New().String()
+			response := fmt.Sprintf(`{"token":"%s"}`, token)
+			w.Write([]byte(response))
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error": "Invalid endpoint"}`))
+	}))
+	defer dtrackServer.Close()
+
+	// Set environment variable for Dependency-Track API key
+	os.Setenv("DTRACK_API_KEY", "dummy-key")
+	defer os.Unsetenv("DTRACK_API_KEY")
+
+	// Setup command
+	cmd := rootCmd
+	cmd.SetArgs([]string{
+		"transfer",
+		"--input-adapter=folder",
+		"--in-folder-path=" + folderPath,
+		"--output-adapter=dtrack",
+		"--out-dtrack-url=" + dtrackServer.URL,
+		"-D",
+	})
+
+	// Set up buffers for capturing output
+	outBuf := bytes.NewBuffer(nil)
+	errBuf := bytes.NewBuffer(nil)
+
+	// Create a pipe to capture os.Stdout (logger output)
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Failed to create pipe: %v", err)
+	}
+	os.Stdout = w
+
+	// Redirect command output/error (optional, for completeness)
+	cmd.SetOut(outBuf)
+	cmd.SetErr(errBuf)
+
+	// Run the command
+	t.Log("Before Execute")
+	err = cmd.Execute()
+
+	// Close the writer and restore os.Stdout
+	w.Close()
+	os.Stdout = origStdout
+
+	// Copy pipe contents to outBuf
+	_, err = io.Copy(outBuf, r)
+	if err != nil {
+		t.Fatalf("Failed to copy pipe output: %v", err)
+	}
+
+	t.Logf("Execute error: %v", err)
+	t.Log("Output:", outBuf.String())
+	t.Log("Errors:", errBuf.String())
+
+	// Assertions
+	assert.NoError(t, err, "Expected no error for valid SBOM transfer")
+	assert.Contains(t, outBuf.String(), "Initializing Input Adapter", "Expected Input adapter Initialization")
+	assert.Contains(t, outBuf.String(), `{"InputAdapter": "folder"}`, "Expected Input adapter")
+
+	assert.Contains(t, outBuf.String(), "Initializing Output Adapter", "Expected Output adapter Initialization")
+	assert.Contains(t, outBuf.String(), `{"OutputAdapter": "dtrack"}`, "Expected Output adapter")
+
+	assert.Contains(t, outBuf.String(), "Locally SBOM located folder", "Expected sbom fetching")
+	assert.Contains(t, outBuf.String(), `{"path": "../testdata/github"}`, "Expected folder path")
+
+	assert.Contains(t, outBuf.String(), "Initializing SBOMs uploading to Dependency-Track sequentially", "Expected upload start")
+
+	assert.Contains(t, outBuf.String(), "New project will be created", "Expected project creation")
+	assert.Contains(t, outBuf.String(), `{"project": "com.github.interlynk-io/sbomqs-main", "version": "main", "uuid": "39a35c94-b369-46e2-b67f-aed235cbc9c1"}`, "Expected new project details")
+
+	assert.Contains(t, outBuf.String(), "Processing Uploading SBOMs", "Expected successful upload completion")
+	assert.Contains(t, outBuf.String(), `{"project": "com.github.interlynk-io/sbomqs-main", "version": "main"}`, "Expected project upload processsing")
+
+	assert.Contains(t, outBuf.String(), "Successfully Uploaded", "Expected successful upload completion")
+	assert.Contains(t, outBuf.String(), `{"Total count": 1, "Success": 1, "Failed": 0}`, "Expected upload counts")
+}
+
+// TEST: uploaded folder to dtrack with a provided project name
+func TestUploadFolderToDTrack_WithProjectName(t *testing.T) {
 	// Check if SBOM folder exists
 	folderPath := SBOMFolderPath()
 	if _, err := os.Stat(folderPath); os.IsNotExist(err) {
@@ -260,6 +384,119 @@ func TestTransferFolderToDependencyTrack_ValidSBOMs(t *testing.T) {
 	assert.Contains(t, outBuf.String(), `{"path": "../testdata/github"}`, "Expected folder path")
 	assert.Contains(t, outBuf.String(), "Initializing SBOMs uploading to Dependency-Track sequentially", "Expected upload start")
 	assert.Contains(t, outBuf.String(), "New project will be created", "Expected project creation")
+	assert.Contains(t, outBuf.String(), "Successfully Uploaded", "Expected successful upload completion")
+	assert.Contains(t, outBuf.String(), `{"Total count": 1, "Success": 1, "Failed": 0}`, "Expected upload counts")
+}
+
+// TEST:  uploaded folder to dtrack with a project name and version
+func TestUploadFolderToDTrack_WithProjectNameAndVersion(t *testing.T) {
+	// Check if SBOM folder exists
+	folderPath := SBOMFolderPath()
+	if _, err := os.Stat(folderPath); os.IsNotExist(err) {
+		t.Skipf("SBOM folder %s does not exist, skipping test", folderPath)
+	}
+
+	dtrackServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/health" {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"status": "ok"}`))
+			return
+		}
+		if r.Method == "GET" && r.URL.Path == "/api/version" {
+			w.Write([]byte(`{"version":"4.12.5","timestamp":"2025-02-17T15:58:13Z","uuid":"550e8400-e29b-41d4-a716-446655440000"}`))
+			return
+		}
+		if r.Method == "GET" && r.URL.Path == "/api/v1/project" {
+			w.Write([]byte(`[]`))
+			return
+		}
+		if r.Method == "PUT" && r.URL.Path == "/api/v1/project" {
+			w.Write([]byte(`{"uuid": "39a35c94-b369-46e2-b67f-aed235cbc9c1", "name": "test-project-v1.0.1", "version": "v1.0.1"}`))
+			return
+		}
+		if r.Method == "PUT" && r.URL.Path == "/api/v1/bom" {
+			w.WriteHeader(http.StatusOK)
+			token := uuid.New().String()
+			response := fmt.Sprintf(`{"token":"%s"}`, token)
+			w.Write([]byte(response))
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error": "Invalid endpoint"}`))
+	}))
+	defer dtrackServer.Close()
+
+	// Set environment variable for Dependency-Track API key
+	os.Setenv("DTRACK_API_KEY", "dummy-key")
+	defer os.Unsetenv("DTRACK_API_KEY")
+
+	// Setup command
+	cmd := rootCmd
+	cmd.SetArgs([]string{
+		"transfer",
+		"--input-adapter=folder",
+		"--in-folder-path=" + folderPath,
+		"--output-adapter=dtrack",
+		"--out-dtrack-url=" + dtrackServer.URL,
+		"--out-dtrack-project-name=test-project",
+		"--out-dtrack-project-version=v1.0.1",
+		"--processing-mode=sequential",
+		"-D",
+	})
+
+	// Set up buffers for capturing output
+	outBuf := bytes.NewBuffer(nil)
+	errBuf := bytes.NewBuffer(nil)
+
+	// Create a pipe to capture os.Stdout (logger output)
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Failed to create pipe: %v", err)
+	}
+	os.Stdout = w
+
+	// Redirect command output/error (optional, for completeness)
+	cmd.SetOut(outBuf)
+	cmd.SetErr(errBuf)
+
+	// Run the command
+	t.Log("Before Execute")
+	err = cmd.Execute()
+
+	// Close the writer and restore os.Stdout
+	w.Close()
+	os.Stdout = origStdout
+
+	// Copy pipe contents to outBuf
+	_, err = io.Copy(outBuf, r)
+	if err != nil {
+		t.Fatalf("Failed to copy pipe output: %v", err)
+	}
+
+	t.Logf("Execute error: %v", err)
+	t.Log("Output:", outBuf.String())
+	t.Log("Errors:", errBuf.String())
+
+	// Assertions
+	assert.NoError(t, err, "Expected no error for valid SBOM transfer")
+	assert.Contains(t, outBuf.String(), "Initializing Input Adapter", "Expected Input adapter Initialization")
+	assert.Contains(t, outBuf.String(), `{"InputAdapter": "folder"}`, "Expected Input adapter")
+
+	assert.Contains(t, outBuf.String(), "Initializing Output Adapter", "Expected Output adapter Initialization")
+	assert.Contains(t, outBuf.String(), `{"OutputAdapter": "dtrack"}`, "Expected Output adapter")
+
+	assert.Contains(t, outBuf.String(), "Locally SBOM located folder", "Expected sbom fetching")
+	assert.Contains(t, outBuf.String(), `{"path": "../testdata/github"}`, "Expected folder path")
+
+	assert.Contains(t, outBuf.String(), "Initializing SBOMs uploading to Dependency-Track sequentially", "Expected upload start")
+
+	assert.Contains(t, outBuf.String(), "New project will be created", "Expected project creation")
+	assert.Contains(t, outBuf.String(), `{"project": "test-project-v1.0.1", "version": "v1.0.1", "uuid": "39a35c94-b369-46e2-b67f-aed235cbc9c1"}`, "Expected new project details")
+
+	assert.Contains(t, outBuf.String(), "Processing Uploading SBOMs", "Expected successful upload completion")
+	assert.Contains(t, outBuf.String(), `{"project": "test-project-v1.0.1", "version": "v1.0.1"}`, "Expected project upload processsing")
+
 	assert.Contains(t, outBuf.String(), "Successfully Uploaded", "Expected successful upload completion")
 	assert.Contains(t, outBuf.String(), `{"Total count": 1, "Success": 1, "Failed": 0}`, "Expected upload counts")
 }

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/spdx/tools-golang v0.5.5
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.0
+	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.27.0
 	sigs.k8s.io/release-utils v0.11.0
 )
@@ -21,9 +22,11 @@ require (
 	github.com/CycloneDX/cyclonedx-go v0.9.2 // indirect
 	github.com/anchore/go-struct-converter v0.0.0-20250211213226-cce56d595160 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/mod v0.24.0 // indirect
 	google.golang.org/protobuf v1.36.5 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect

--- a/pkg/logger/log.go
+++ b/pkg/logger/log.go
@@ -101,3 +101,11 @@ func LogDebug(ctx context.Context, msg string, keysAndValues ...interface{}) {
 func LogInfo(ctx context.Context, msg string, keysAndValues ...interface{}) {
 	FromContext(ctx).Infow(msg, keysAndValues...)
 }
+
+// DeinitLogger deinitializes the logger by syncing and resetting it.
+func DeinitLogger() {
+	if logger != nil {
+		_ = logger.Sync()
+		logger = nil
+	}
+}

--- a/pkg/source/github/client.go
+++ b/pkg/source/github/client.go
@@ -441,7 +441,6 @@ func (c *Client) GetAllRepositories(ctx tcontext.TransferMetadata) ([]string, er
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.Token))
 	}
 
-	// Set required headers
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
 
 	resp, err := c.httpClient.Do(req)
@@ -450,14 +449,13 @@ func (c *Client) GetAllRepositories(ctx tcontext.TransferMetadata) ([]string, er
 	}
 	defer resp.Body.Close()
 
-	// Check if response is successful
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("GitHub API returned status %d: %s", resp.StatusCode, string(body))
 	}
 
 	// Decode the JSON response
-	var repos []map[string]interface{} // Handle dynamic JSON structure
+	var repos []map[string]interface{}
 	if err := json.NewDecoder(resp.Body).Decode(&repos); err != nil {
 		return nil, fmt.Errorf("decoding response: %w", err)
 	}

--- a/pkg/target/dependencytrack/adapter.go
+++ b/pkg/target/dependencytrack/adapter.go
@@ -116,17 +116,15 @@ func (d *DependencyTrackAdapter) ParseAndValidateParams(cmd *cobra.Command) erro
 		uploader = NewParallelUploader()
 	}
 
-	cfg := NewDependencyTrackConfig()
-	cfg.APIURL = apiURL
+	cfg := NewDependencyTrackConfig(apiURL, projectVersion)
 	cfg.APIKey = token
 	cfg.ProjectName = projectName
-	cfg.ProjectVersion = projectVersion
 
 	// Set values to struct
 	d.Config = cfg
 
 	// Initialize the DependencyTrack client
-	client := NewDependencyTrackClient(d.Config)
+	client := NewDependencyTrackClient(cfg)
 	d.client = client
 	d.Uploader = uploader
 

--- a/pkg/target/dependencytrack/client.go
+++ b/pkg/target/dependencytrack/client.go
@@ -57,6 +57,11 @@ func (c *DependencyTrackClient) FindProject(ctx tcontext.TransferMetadata, proje
 		return "", err
 	}
 
+	if projects.Items == nil {
+		logger.LogDebug(ctx.Context, "No projects found or nil response")
+		return "", nil
+	}
+
 	logger.LogDebug(ctx.Context, "Total Number of Projects Available in Dependency Track Platform", "count", projects.TotalCount)
 
 	for _, project := range projects.Items {

--- a/pkg/target/dependencytrack/config.go
+++ b/pkg/target/dependencytrack/config.go
@@ -21,9 +21,9 @@ type DependencyTrackConfig struct {
 	ProjectVersion string // Added field for project version
 }
 
-func NewDependencyTrackConfig() *DependencyTrackConfig {
+func NewDependencyTrackConfig(apiURL, version string) *DependencyTrackConfig {
 	return &DependencyTrackConfig{
-		APIURL:         "http://localhost:8081/api/v1",
-		ProjectVersion: "latest", // Default version
+		APIURL:         apiURL,
+		ProjectVersion: version,
 	}
 }

--- a/testdata/github/sbomqs_github_api_sbom.spdx.json
+++ b/testdata/github/sbomqs_github_api_sbom.spdx.json
@@ -1,0 +1,1178 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "com.github.interlynk-io/sbomqs",
+  "documentNamespace": "https://spdx.org/spdxdocs/protobom/e17d7ba6-c20e-4a2b-8ce9-08317e5f5828",
+  "creationInfo": {
+    "creators": [
+      "Tool: protobom-v0.0.0-20250321152316-d9fe4525931d+dirty",
+      "Tool: GitHub.com-Dependency-Graph"
+    ],
+    "created": "2025-03-24T13:48:00Z"
+  },
+  "packages": [
+    {
+      "name": "golang.org/x/sync",
+      "SPDXID": "SPDXRef-golang-golang.orgx-sync-0.11.0-75c946",
+      "versionInfo": "0.11.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/golang.org/x/sync@0.11.0"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/oauth2",
+      "SPDXID": "SPDXRef-golang-golang.orgx-oauth2-0.26.0-75c946",
+      "versionInfo": "0.26.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/golang.org/x/oauth2@0.26.0"
+        }
+      ]
+    },
+    {
+      "name": "github.com/anchore/go-struct-converter",
+      "SPDXID": "SPDXRef-golang-github.comanchore-go-struct-converter-0.0.0-20250211213226-cce56d595160-75c946",
+      "versionInfo": "0.0.0-20250211213226-cce56d595160",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/anchore/go-struct-converter@0.0.0-20250211213226-cce56d595160"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/crypto",
+      "SPDXID": "SPDXRef-golang-golang.orgx-crypto-0.33.0-75c946",
+      "versionInfo": "0.33.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/golang.org/x/crypto@0.33.0"
+        }
+      ]
+    },
+    {
+      "name": "github.com/samber/lo",
+      "SPDXID": "SPDXRef-golang-github.comsamber-lo-1.49.1-75c946",
+      "versionInfo": "1.49.1",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/samber/lo@1.49.1"
+        }
+      ]
+    },
+    {
+      "name": "golangci/golangci-lint-action",
+      "SPDXID": "SPDXRef-githubactions-golangci-golangci-lint-action-6..-75c946",
+      "versionInfo": "6.*.*",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:githubactions/golangci/golangci-lint-action@6.%2A.%2A"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/cobra",
+      "SPDXID": "SPDXRef-golang-github.comspf13-cobra-1.9.1-75c946",
+      "versionInfo": "1.9.1",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/spf13/cobra@1.9.1"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mattn/go-runewidth",
+      "SPDXID": "SPDXRef-golang-github.commattn-go-runewidth-0.0.16-75c946",
+      "versionInfo": "0.0.16",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/mattn/go-runewidth@0.0.16"
+        }
+      ]
+    },
+    {
+      "name": "github.com/pmezard/go-difflib",
+      "SPDXID": "SPDXRef-golang-github.compmezard-go-difflib-1.0.0-75c946",
+      "versionInfo": "1.0.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/pmezard/go-difflib@1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "github.com/olekukonko/tablewriter",
+      "SPDXID": "SPDXRef-golang-github.comolekukonko-tablewriter-0.0.5-75c946",
+      "versionInfo": "0.0.5",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/olekukonko/tablewriter@0.0.5"
+        }
+      ]
+    },
+    {
+      "name": "github.com/tidwall/match",
+      "SPDXID": "SPDXRef-golang-github.comtidwall-match-1.1.1-75c946",
+      "versionInfo": "1.1.1",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/tidwall/match@1.1.1"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spdx/tools-golang",
+      "SPDXID": "SPDXRef-golang-github.comspdx-tools-golang-0.5.5-75c946",
+      "versionInfo": "0.5.5",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/spdx/tools-golang@0.5.5"
+        }
+      ]
+    },
+    {
+      "name": "actions/setup-python",
+      "SPDXID": "SPDXRef-githubactions-actions-setup-python-4..-75c946",
+      "versionInfo": "4.*.*",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:githubactions/actions/setup-python@4.%2A.%2A"
+        }
+      ]
+    },
+    {
+      "name": "github.com/inconshreveable/mousetrap",
+      "SPDXID": "SPDXRef-golang-github.cominconshreveable-mousetrap-1.1.0-75c946",
+      "versionInfo": "1.1.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/inconshreveable/mousetrap@1.1.0"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spdx/gordf",
+      "SPDXID": "SPDXRef-golang-github.comspdx-gordf-0.0.0-20250128162952-000978ccd6fb-75c946",
+      "versionInfo": "0.0.0-20250128162952-000978ccd6fb",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/spdx/gordf@0.0.0-20250128162952-000978ccd6fb"
+        }
+      ]
+    },
+    {
+      "name": "docker/metadata-action",
+      "SPDXID": "SPDXRef-githubactions-docker-metadata-action-5..-75c946",
+      "versionInfo": "5.*.*",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:githubactions/docker/metadata-action@5.%2A.%2A"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mattn/go-isatty",
+      "SPDXID": "SPDXRef-golang-github.commattn-go-isatty-0.0.20-75c946",
+      "versionInfo": "0.0.20",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/mattn/go-isatty@0.0.20"
+        }
+      ]
+    },
+    {
+      "name": "github.com/pkg/errors",
+      "SPDXID": "SPDXRef-golang-github.compkg-errors-0.9.1-75c946",
+      "versionInfo": "0.9.1",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/pkg/errors@0.9.1"
+        }
+      ]
+    },
+    {
+      "name": "gotest.tools",
+      "SPDXID": "SPDXRef-golang-gotest.tools-2.2.0incompatible-75c946",
+      "versionInfo": "2.2.0+incompatible",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/gotest.tools@2.2.0%2Bincompatible"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-github/v52",
+      "SPDXID": "SPDXRef-golang-github.comgooglego-github-v52-52.0.0-75c946",
+      "versionInfo": "52.0.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/google/go-github/v52@52.0.0"
+        }
+      ]
+    },
+    {
+      "name": "github.com/go-git/go-billy/v5",
+      "SPDXID": "SPDXRef-golang-github.comgo-gitgo-billy-v5-5.6.2-75c946",
+      "versionInfo": "5.6.2",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/go-git/go-billy/v5@5.6.2"
+        }
+      ]
+    },
+    {
+      "name": "github.com/ProtonMail/go-crypto",
+      "SPDXID": "SPDXRef-golang-github.comprotonmail-go-crypto-1.1.5-75c946",
+      "versionInfo": "1.1.5",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/protonmail/go-crypto@1.1.5"
+        }
+      ]
+    },
+    {
+      "name": "github.com/DependencyTrack/client-go",
+      "SPDXID": "SPDXRef-golang-github.comdependencytrack-client-go-0.15.0-75c946",
+      "versionInfo": "0.15.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/dependencytrack/client-go@0.15.0"
+        }
+      ]
+    },
+    {
+      "name": "docker/setup-qemu-action",
+      "SPDXID": "SPDXRef-githubactions-docker-setup-qemu-action-3..-75c946",
+      "versionInfo": "3.*.*",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:githubactions/docker/setup-qemu-action@3.%2A.%2A"
+        }
+      ]
+    },
+    {
+      "name": "github.com/davecgh/go-spew",
+      "SPDXID": "SPDXRef-golang-github.comdavecgh-go-spew-1.1.1-75c946",
+      "versionInfo": "1.1.1",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/davecgh/go-spew@1.1.1"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v3",
+      "SPDXID": "SPDXRef-golang-gopkg.in-yaml.v3-3.0.1-75c946",
+      "versionInfo": "3.0.1",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/gopkg.in/yaml.v3@3.0.1"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/release-utils",
+      "SPDXID": "SPDXRef-golang-sigs.k8s.io-release-utils-0.11.0-75c946",
+      "versionInfo": "0.11.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/sigs.k8s.io/release-utils@0.11.0"
+        }
+      ]
+    },
+    {
+      "name": "github.com/common-nighthawk/go-figure",
+      "SPDXID": "SPDXRef-golang-github.comcommon-nighthawk-go-figure-0.0.0-20210622060536-734e95fb86be-75c946",
+      "versionInfo": "0.0.0-20210622060536-734e95fb86be",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/common-nighthawk/go-figure@0.0.0-20210622060536-734e95fb86be"
+        }
+      ]
+    },
+    {
+      "name": "github.com/github/go-spdx/v2",
+      "SPDXID": "SPDXRef-golang-github.comgithubgo-spdx-v2-2.3.2-75c946",
+      "versionInfo": "2.3.2",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/github/go-spdx/v2@2.3.2"
+        }
+      ]
+    },
+    {
+      "name": "github.com/stretchr/testify",
+      "SPDXID": "SPDXRef-golang-github.comstretchr-testify-1.10.0-75c946",
+      "versionInfo": "1.10.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/stretchr/testify@1.10.0"
+        }
+      ]
+    },
+    {
+      "name": "github.com/maxbrunsfeld/counterfeiter/v6",
+      "SPDXID": "SPDXRef-golang-github.commaxbrunsfeldcounterfeiter-v6-6.11.2-75c946",
+      "versionInfo": "6.11.2",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/maxbrunsfeld/counterfeiter/v6@6.11.2"
+        }
+      ]
+    },
+    {
+      "name": "gopkg.in/yaml.v2",
+      "SPDXID": "SPDXRef-golang-gopkg.in-yaml.v2-2.4.0-75c946",
+      "versionInfo": "2.4.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/gopkg.in/yaml.v2@2.4.0"
+        }
+      ]
+    },
+    {
+      "name": "sigs.k8s.io/yaml",
+      "SPDXID": "SPDXRef-golang-sigs.k8s.io-yaml-1.4.0-75c946",
+      "versionInfo": "1.4.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/sigs.k8s.io/yaml@1.4.0"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/mod",
+      "SPDXID": "SPDXRef-golang-golang.orgx-mod-0.23.0-75c946",
+      "versionInfo": "0.23.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/golang.org/x/mod@0.23.0"
+        }
+      ]
+    },
+    {
+      "name": "goreleaser/goreleaser-action",
+      "SPDXID": "SPDXRef-githubactions-goreleaser-goreleaser-action-6..-75c946",
+      "versionInfo": "6.*.*",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:githubactions/goreleaser/goreleaser-action@6.%2A.%2A"
+        }
+      ]
+    },
+    {
+      "name": "github.com/CycloneDX/cyclonedx-go",
+      "SPDXID": "SPDXRef-golang-github.comcyclonedx-cyclonedx-go-0.9.2-75c946",
+      "versionInfo": "0.9.2",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/cyclonedx/cyclonedx-go@0.9.2"
+        }
+      ]
+    },
+    {
+      "name": "docker/login-action",
+      "SPDXID": "SPDXRef-githubactions-docker-login-action-3..-75c946",
+      "versionInfo": "3.*.*",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:githubactions/docker/login-action@3.%2A.%2A"
+        }
+      ]
+    },
+    {
+      "name": "docker/build-push-action",
+      "SPDXID": "SPDXRef-githubactions-docker-build-push-action-6..-75c946",
+      "versionInfo": "6.*.*",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:githubactions/docker/build-push-action@6.%2A.%2A"
+        }
+      ]
+    },
+    {
+      "name": "github.com/tidwall/gjson",
+      "SPDXID": "SPDXRef-golang-github.comtidwall-gjson-1.18.0-75c946",
+      "versionInfo": "1.18.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/tidwall/gjson@1.18.0"
+        }
+      ]
+    },
+    {
+      "name": "github.com/fatih/color",
+      "SPDXID": "SPDXRef-golang-github.comfatih-color-1.18.0-75c946",
+      "versionInfo": "1.18.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/fatih/color@1.18.0"
+        }
+      ]
+    },
+    {
+      "name": "github.com/tidwall/pretty",
+      "SPDXID": "SPDXRef-golang-github.comtidwall-pretty-1.2.1-75c946",
+      "versionInfo": "1.2.1",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/tidwall/pretty@1.2.1"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/uuid",
+      "SPDXID": "SPDXRef-golang-github.comgoogle-uuid-1.6.0-75c946",
+      "versionInfo": "1.6.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/google/uuid@1.6.0"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-querystring",
+      "SPDXID": "SPDXRef-golang-github.comgoogle-go-querystring-1.1.0-75c946",
+      "versionInfo": "1.1.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/google/go-querystring@1.1.0"
+        }
+      ]
+    },
+    {
+      "name": "github.com/tidwall/sjson",
+      "SPDXID": "SPDXRef-golang-github.comtidwall-sjson-1.2.5-75c946",
+      "versionInfo": "1.2.5",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/tidwall/sjson@1.2.5"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/sys",
+      "SPDXID": "SPDXRef-golang-golang.orgx-sys-0.30.0-75c946",
+      "versionInfo": "0.30.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/golang.org/x/sys@0.30.0"
+        }
+      ]
+    },
+    {
+      "name": "actions/setup-go",
+      "SPDXID": "SPDXRef-githubactions-actions-setup-go-5..-75c946",
+      "versionInfo": "5.*.*",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:githubactions/actions/setup-go@5.%2A.%2A"
+        }
+      ]
+    },
+    {
+      "name": "github.com/google/go-cmp",
+      "SPDXID": "SPDXRef-golang-github.comgoogle-go-cmp-0.6.0-75c946",
+      "versionInfo": "0.6.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/google/go-cmp@0.6.0"
+        }
+      ]
+    },
+    {
+      "name": "github.com/rivo/uniseg",
+      "SPDXID": "SPDXRef-golang-github.comrivo-uniseg-0.4.7-75c946",
+      "versionInfo": "0.4.7",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/rivo/uniseg@0.4.7"
+        }
+      ]
+    },
+    {
+      "name": "github.com/mattn/go-colorable",
+      "SPDXID": "SPDXRef-golang-github.commattn-go-colorable-0.1.14-75c946",
+      "versionInfo": "0.1.14",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/mattn/go-colorable@0.1.14"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/pflag",
+      "SPDXID": "SPDXRef-golang-github.comspf13-pflag-1.0.6-75c946",
+      "versionInfo": "1.0.6",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/spf13/pflag@1.0.6"
+        }
+      ]
+    },
+    {
+      "name": "go.uber.org/multierr",
+      "SPDXID": "SPDXRef-golang-go.uber.org-multierr-1.11.0-75c946",
+      "versionInfo": "1.11.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/go.uber.org/multierr@1.11.0"
+        }
+      ]
+    },
+    {
+      "name": "go.uber.org/zap",
+      "SPDXID": "SPDXRef-golang-go.uber.org-zap-1.27.0-75c946",
+      "versionInfo": "1.27.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/go.uber.org/zap@1.27.0"
+        }
+      ]
+    },
+    {
+      "name": "github.com/package-url/packageurl-go",
+      "SPDXID": "SPDXRef-golang-github.compackage-url-packageurl-go-0.1.3-75c946",
+      "versionInfo": "0.1.3",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/package-url/packageurl-go@0.1.3"
+        }
+      ]
+    },
+    {
+      "name": "github.com/Masterminds/semver/v3",
+      "SPDXID": "SPDXRef-golang-github.commastermindssemver-v3-3.3.1-75c946",
+      "versionInfo": "3.3.1",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/masterminds/semver/v3@3.3.1"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/text",
+      "SPDXID": "SPDXRef-golang-golang.orgx-text-0.22.0-75c946",
+      "versionInfo": "0.22.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/golang.org/x/text@0.22.0"
+        }
+      ]
+    },
+    {
+      "name": "actions/checkout",
+      "SPDXID": "SPDXRef-githubactions-actions-checkout-4..-75c946",
+      "versionInfo": "4.*.*",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:githubactions/actions/checkout@4.%2A.%2A"
+        }
+      ]
+    },
+    {
+      "name": "github.com/spf13/afero",
+      "SPDXID": "SPDXRef-golang-github.comspf13-afero-1.12.0-75c946",
+      "versionInfo": "1.12.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/spf13/afero@1.12.0"
+        }
+      ]
+    },
+    {
+      "name": "github.com/cloudflare/circl",
+      "SPDXID": "SPDXRef-golang-github.comcloudflare-circl-1.6.0-75c946",
+      "versionInfo": "1.6.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/github.com/cloudflare/circl@1.6.0"
+        }
+      ]
+    },
+    {
+      "name": "golang.org/x/tools",
+      "SPDXID": "SPDXRef-golang-golang.orgx-tools-0.30.0-75c946",
+      "versionInfo": "0.30.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:golang/golang.org/x/tools@0.30.0"
+        }
+      ]
+    },
+    {
+      "name": "docker/setup-buildx-action",
+      "SPDXID": "SPDXRef-githubactions-docker-setup-buildx-action-3..-75c946",
+      "versionInfo": "3.*.*",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:githubactions/docker/setup-buildx-action@3.%2A.%2A"
+        }
+      ]
+    },
+    {
+      "name": "com.github.interlynk-io/sbomqs",
+      "SPDXID": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "versionInfo": "main",
+      "downloadLocation": "git+https://github.com/interlynk-io/sbomqs",
+      "filesAnalyzed": false,
+      "licenseDeclared": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:github/interlynk-io/sbomqs@main"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-golang.orgx-crypto-0.33.0-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-sigs.k8s.io-release-utils-0.11.0-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-golang.orgx-text-0.22.0-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.comgooglego-github-v52-52.0.0-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.comstretchr-testify-1.10.0-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.commattn-go-runewidth-0.0.16-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-gotest.tools-2.2.0incompatible-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-golang.orgx-tools-0.30.0-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-githubactions-docker-setup-buildx-action-3..-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.compmezard-go-difflib-1.0.0-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.comdavecgh-go-spew-1.1.1-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.comgoogle-uuid-1.6.0-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.cominconshreveable-mousetrap-1.1.0-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.comprotonmail-go-crypto-1.1.5-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.comrivo-uniseg-0.4.7-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-go.uber.org-multierr-1.11.0-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-githubactions-docker-setup-qemu-action-3..-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-gopkg.in-yaml.v3-3.0.1-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-githubactions-docker-login-action-3..-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.comtidwall-gjson-1.18.0-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.comtidwall-pretty-1.2.1-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-githubactions-actions-setup-go-5..-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-githubactions-actions-checkout-4..-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.compackage-url-packageurl-go-0.1.3-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.comspf13-cobra-1.9.1-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.comspdx-gordf-0.0.0-20250128162952-000978ccd6fb-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.comgithubgo-spdx-v2-2.3.2-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-golang.orgx-mod-0.23.0-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.comgoogle-go-cmp-0.6.0-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.comspf13-pflag-1.0.6-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.comspdx-tools-golang-0.5.5-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.comfatih-color-1.18.0-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-golang.orgx-sync-0.11.0-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.comsamber-lo-1.49.1-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-githubactions-golangci-golangci-lint-action-6..-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.commattn-go-isatty-0.0.20-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-gopkg.in-yaml.v2-2.4.0-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-sigs.k8s.io-yaml-1.4.0-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-go.uber.org-zap-1.27.0-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-githubactions-goreleaser-goreleaser-action-6..-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-githubactions-docker-build-push-action-6..-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.comtidwall-sjson-1.2.5-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.commattn-go-colorable-0.1.14-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.comspf13-afero-1.12.0-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.comcloudflare-circl-1.6.0-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-golang.orgx-oauth2-0.26.0-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.comanchore-go-struct-converter-0.0.0-20250211213226-cce56d595160-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.comolekukonko-tablewriter-0.0.5-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-githubactions-docker-metadata-action-5..-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.comcommon-nighthawk-go-figure-0.0.0-20210622060536-734e95fb86be-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.commaxbrunsfeldcounterfeiter-v6-6.11.2-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-golang.orgx-sys-0.30.0-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.commastermindssemver-v3-3.3.1-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.comtidwall-match-1.1.1-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-githubactions-actions-setup-python-4..-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.compkg-errors-0.9.1-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.comgo-gitgo-billy-v5-5.6.2-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.comdependencytrack-client-go-0.15.0-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.comcyclonedx-cyclonedx-go-0.9.2-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relatedSpdxElement": "SPDXRef-golang-github.comgoogle-go-querystring-1.1.0-75c946",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relatedSpdxElement": "SPDXRef-github-interlynk-io-sbomqs-main-44d2e7",
+      "relationshipType": "DESCRIBES"
+    }
+  ]
+}


### PR DESCRIPTION
Related to https://github.com/interlynk-io/sbommv/issues/100

This PR updates the following changes:
- It adds the unit test `TestTransferGitHubToDependencyTrack_ValidRepo_WithProject` to verify the SBOM transfer functionality from GitHub to Dependency-Track in the sbommv tool.
- For testing we are mocking github server and dependency track server for various request to get mocked dats.
- Mocked GitHub Server: Uses `httptest.NewServer` to simulate the GitHub Dependency Graph API (`/repos/interlynk-io/sbomqs/dependency-graph/sbom`), returning a pre-loaded SPDX SBOM file (sbomqs_github_api_sbom.spdx.json) from the test folder.
- Mocked Dependency-Track Server: Simulates Dependency-Track API endpoints:
  - GET /health: Returns {"status": "ok"}.
  - GET /api/version: Returns version info.
  - GET /api/v1/project: Returns an empty project list ([]).
  - PUT /api/v1/project: Creates a project with a fixed UUID and returns project details.
  - PUT /api/v1/bom: Uploads the SBOM and returns a generated UUID token.
  - Returns 400 for invalid endpoints. 
  
It covers following cases:
- Github to Dtrack
  -  upload github_api to dtrack(`TestUploadGithubAPIToDTrack`)
  - upload github_api to dtrack with a project name(`TestUploadGithubAPIToDTrack_WithProjectName`)
  - upload github_api to dtrack with a project name and version(`TestUploadGithubAPIToDTrack_WithProjectNameAndVersion`)
- Folder to DTrack
  - uploaded folder to dtrack(`TestUploadFolderToDTrack`)
  - uploaded folder to dtrack with a project name(`TestUploadFolderToDTrack_WithProjectName`)
  - uploaded folder to dtrack with a project name and version*`TestUploadFolderToDTrack_WithProjectNameAndVersion`)
  
  NOTE: The test expected o/p depends on logging message, so change in logging message would affect it.