### PR TITLE
Fix/folder monitoring

### DIFF
--- a/pkg/source/folder/adapter.go
+++ b/pkg/source/folder/adapter.go
@@ -120,7 +120,7 @@ func (f *FolderAdapter) Monitor(ctx tcontext.TransferMetadata) (iterator.SBOMIte
 		return nil, fmt.Errorf("daemon mode not enabled for folder adapter")
 	}
 
-	logger.LogDebug(ctx.Context, "Initializing SBOM monitoring")
+	logger.LogInfo(ctx.Context, "Initializing SBOM real-time monitoring for folder in daemon mode", "path", f.Config.FolderPath)
 	return f.Fetcher.Fetch(ctx, f.Config)
 }
 

--- a/pkg/source/github/adapter.go
+++ b/pkg/source/github/adapter.go
@@ -270,7 +270,7 @@ func (g *GitHubAdapter) FetchSBOMs(ctx tcontext.TransferMetadata) (iterator.SBOM
 }
 
 func (g *GitHubAdapter) Monitor(ctx tcontext.TransferMetadata) (iterator.SBOMIterator, tcontext.TransferMetadata, error) {
-	return nil, ctx, fmt.Errorf("Currently gitHub adapter does not support monitoring")
+	return nil, ctx, fmt.Errorf("GitHub adapter does not support real-time monitoring in daemon mode")
 }
 
 // OutputSBOMs should return an error since GitHub does not support SBOM uploads


### PR DESCRIPTION
related to: https://github.com/interlynk-io/sbommv/issues/59

This PR adds the following changes:
 
- When a folder (`abc`) with existing files is moved up into the watched directory (`demo`) triggers an event for the folder and processes its files. Continuous monitoring of `abc` (now a subdirectory of `demo`) occurs only if `--in-folder-recursive=true` is set.
- When an existing file is renamed in the watched directory (`demo`) triggers the appropriate event (`RENAME` or `REPLACE`) and is handled accordingly.
- Improved logging messages.
- Implement `dry-run` mode for daemon mode