### PR TITLE
[refractor]: decoupling sequential and parallel downloads while fetching SBOMs in github adapter

### DIFF
--- a/pkg/source/utils.go
+++ b/pkg/source/utils.go
@@ -30,7 +30,7 @@ func init() {
 	sbomRegex = regexp.MustCompile(`(sbom|bom|spdx|cdx)[-_\.].+\.(json|xml|yaml|yml|txt)$`)
 }
 
-// IsSBOMFile simply detect SBOMs file format and spec after reading the file.
+// IsSBOMFile detect SBOMs file format and spec after reading the content of SBOM file.
 func IsSBOMFile(content []byte) bool {
 	reader := bytes.NewReader(content)
 	spec, format, err := detect.Detect(reader)


### PR DESCRIPTION
This PR adds the following changes:

- Decoupled Sequential and Concurrent Fetching:
  - Previously, both sequential and concurrent modes relied on `fetchSBOMFromReleases`, which used concurrent downloading (3 goroutines) even for sequential fetching. This PR separates them:
    - Sequential mode now downloads SBOMs one-by-one, i.e. sequential processing.
    - Concurrent mode performs a concurrency limit of 3 downloads.

- Streamlined SBOM Fetching:
  - Earlier, the process involved two steps:
    - `FindSBOMs` collected metadata (e.g., name, size, download URL).
    - `downloadSBOMs` fetched content using those URLs.
  - Now, `FindSBOMs` handles both metadata retrieval and content downloading in a single step, storing `[]SBOMData` (content and metadata). This eliminates the separate `downloadSBOMs` step, simplifying the pipeline.
