### PR TITLE
improve transfer command o/p for respetive adapter flags and options clarity

### DIFF
--- a/cmd/transfer.go
+++ b/cmd/transfer.go
@@ -60,6 +60,7 @@ func init() {
 	transferCmd.Flags().Bool("dry-run", false, "Simulate transfer without executing")
 	transferCmd.Flags().String("processing-mode", "sequential", "Processing strategy (sequential, parallel)")
 	transferCmd.Flags().Bool("overwrite", false, "Overwrite existing SBOMs at destination")
+	transferCmd.Flags().Bool("guide", false, "Show beginner-friendly guide")
 
 	// Input and Output Adapter Flags(both required)
 	transferCmd.Flags().String("input-adapter", "", "Input adapter type (github, folder, s3)")
@@ -226,6 +227,30 @@ func registerAdapterFlags(cmd *cobra.Command) {
 }
 
 func transferSBOM(cmd *cobra.Command, args []string) error {
+	// Check for guide flag
+	guide, _ := cmd.Flags().GetBool("guide")
+	if guide {
+		fmt.Println(`Welcome to sbommv! The ` + "`transfer`" + ` command moves Software Bill of Materials (SBOMs) from one place to another.
+
+Get started in 3 steps:
+1. Choose an input source (where SBOMs come from):
+   - GitHub: Fetch from repositories (e.g., a project’s code).
+   - Folder: Use SBOM files from a local directory.
+   - S3: Pull SBOMs from an AWS S3 bucket.
+2. Choose an output destination (where SBOMs go):
+   - Folder: Save to a local directory.
+   - S3: Upload to an AWS S3 bucket.
+   - Dependency Track: Send to a Dependency Track server.
+   - Interlynk: Upload to the Interlynk platform.
+3. Run a command like:
+   sbommv transfer --input-adapter=folder --in-folder-path="sboms" --output-adapter=s3 --out-s3-bucket-name="my-bucket" --out-s3-prefix="sboms"
+   sbommv transfer --input-adapter=github --in-github-url="https://github.com/interlynk-io/sbomqs" --output-adapter=dtrack --out-dtrack-url="http://localhost:8081"
+
+For more details and options, run ` + "`sbommv transfer --help`" + `.
+Explore examples at https://github.com/interlynk-io/sbommv/tree/main/examples.`)
+		return nil
+	}
+
 	// Suppress automatic usage message for non-flag errors
 	cmd.SilenceUsage = true
 

--- a/cmd/transfer.go
+++ b/cmd/transfer.go
@@ -17,6 +17,8 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"strings"
+	"text/template"
 
 	"github.com/interlynk-io/sbommv/pkg/engine"
 	ifolder "github.com/interlynk-io/sbommv/pkg/source/folder"
@@ -29,59 +31,175 @@ import (
 
 	"github.com/interlynk-io/sbommv/pkg/logger"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
+
+// FlagData holds information about a flag for template rendering
+type FlagData struct {
+	Name      string
+	Shorthand string
+	Usage     string
+	ValueType string
+}
 
 var transferCmd = &cobra.Command{
 	Use:   "transfer",
 	Short: "Transfer SBOMs between systems",
-	Long: `Transfer SBOMs from a source system (e.g., GitHub) to a target system (e.g., Interlynk).
-
-Example usage:
-# Fetch SBOM for sbomqs latest github release and upload to interlynk platform
-sbommv transfer -D --input-adapter=github --in-github-url="https://github.com/interlynk-io/sbomqs" \
---output-adapter=interlynk --out-interlynk-url="http://localhost:3000/lynkapi"
-
-# Fetch SBOMs using the GitHub adapter via the api method for the latest repository version
-sbommv transfer --input-adapter=github --in-github-url="https://github.com/sigstore/cosign" --in-github-method=api  \
---output-adapter=interlynk --out-interlynk-url="http://localhost:3000/lynkapi"
-
-# Fetch SBOMs from github repo and save it to a folder "temp"
-sbommv transfer --input-adapter=github --in-github-url="https://github.com/sigstore/" --in-github-include-repos=cosign,fulcio,rekor \
---in-github-method="release" --output-adapter=folder --out-folder-path="temp"
-
-# Fetch SBOMs from folder "temp" and upload/push it to a Interlynk
-sbommv transfer --input-adapter=folder --in-folder-path="temp"  --in-folder-recursive=true  --output-adapter=interlynk \
---out-interlynk-url="http://localhost:3000/lynkapi"
-
-	`,
-	Args: cobra.NoArgs,
-	RunE: transferSBOM,
+	Long:  `Transfer SBOMs from a source system (e.g., GitHub) to a target system (e.g., Interlynk).`,
+	Args:  cobra.NoArgs,
+	RunE:  transferSBOM,
 }
 
 func init() {
 	rootCmd.AddCommand(transferCmd)
 
-	// Input adapter flags
-	transferCmd.Flags().String("input-adapter", "", "input adapter type (github, folder)")
+	// General Flags
+	transferCmd.Flags().BoolP("daemon", "d", false, "Enable daemon mode")
+	transferCmd.Flags().BoolP("debug", "D", false, "Enable debug logging")
+	transferCmd.Flags().Bool("dry-run", false, "Simulate transfer without executing")
+	transferCmd.Flags().String("processing-mode", "sequential", "Processing strategy (sequential, parallel)")
+	transferCmd.Flags().Bool("overwrite", false, "Overwrite existing SBOMs at destination")
 
-	// Output adapter flags
-	transferCmd.Flags().String("output-adapter", "", "output adapter type (dtrack, interlynk, folder)")
+	// Input and Output Adapter Flags(both required)
+	transferCmd.Flags().String("input-adapter", "", "Input adapter type (github, folder, s3)")
+	transferCmd.Flags().String("output-adapter", "", "Output adapter type (folder, s3, dtrack, interlynk)")
 
-	transferCmd.Flags().BoolP("dry-run", "", false, "enable dry run mode")
-
-	// processing mode: sequential or parallel
-	transferCmd.Flags().String("processing-mode", "sequential", "processing strategy (parallel, sequential)")
-
-	// enable daemon mode
-	transferCmd.Flags().BoolP("daemon", "d", false, "enable daemon mode")
-
-	transferCmd.Flags().BoolP("debug", "D", false, "enable debug logging")
-
-	transferCmd.Flags().Bool("overwrite", false, "Overwrite existing SBOM (default: false)")
-
-	// Manually register adapter flags for each adapter
 	registerAdapterFlags(transferCmd)
+
+	// Define custom template functions
+	funcMap := template.FuncMap{
+		"prefix": func(s, prefix string) bool {
+			return strings.HasPrefix(s, prefix)
+		},
+		"eq": func(a, b string) bool {
+			return a == b
+		},
+	}
+
+	// define the help template as a string
+	const helpTemplate = `
+{{.Command.Short}}
+
+Usage:
+  {{.Command.UseLine}}
+
+Examples:
+  # GitHub (release) to Folder
+  sbommv transfer --input-adapter=github --in-github-url="https://github.com/interlynk-io/sbomqs" --in-github-method=release \
+                  --output-adapter=folder --out-folder-path="temp"
+
+  # Folder to S3
+  sbommv transfer --input-adapter=folder --in-folder-path="temp" --in-folder-recursive \
+                  --output-adapter=s3 --out-s3-bucket-name="demo-test-sbom" --out-s3-prefix="sboms" --out-s3-region="us-east-1"
+
+  # S3 to Dependency Track
+  sbommv transfer --input-adapter=s3 --in-s3-bucket-name="source-test-sbom" --in-s3-prefix="dropwizard" --in-s3-region="us-east-1" \
+                  --output-adapter=dtrack --out-dtrack-url="http://localhost:8081" --out-dtrack-project-name="my-project"
+
+  # GitHub (api) to Interlynk
+  sbommv transfer --input-adapter=github --in-github-url="https://github.com/interlynk-io/sbomqs" \
+                  --output-adapter=interlynk --out-interlynk-url="http://localhost:3000/lynkapi" --out-interlynk-project-name="sbomqs"
+
+General Flags:
+{{- range .Flags}}
+{{- if and (not (or (prefix .Name "in-") (prefix .Name "out-"))) (not (eq .Name "input-adapter")) (not (eq .Name "output-adapter"))}}
+  {{if .Shorthand}}-{{.Shorthand}}, {{end}}--{{.Name}}{{if eq .ValueType "string"}} string{{end}}  {{.Usage}}
+{{- end}}
+{{- end}}
+
+Input Adapter Flags(required):
+  --input-adapter string  Input adapter type (github, folder, s3)
+
+  GitHub Input Adapter:
+{{- range .Flags}}
+{{- if prefix .Name "in-github-"}}
+    --{{.Name}} {{.ValueType}}  {{.Usage}}
+{{- end}}
+{{- end}}
+
+  Folder Input Adapter(required):
+{{- range .Flags}}
+{{- if prefix .Name "in-folder-"}}
+    --{{.Name}} {{if eq .ValueType "bool"}}{{else}}{{.ValueType}}{{end}}  {{.Usage}}
+{{- end}}
+{{- end}}
+
+  S3 Input Adapter:
+{{- range .Flags}}
+{{- if prefix .Name "in-s3-"}}
+    --{{.Name}} {{.ValueType}}  {{.Usage}}
+{{- end}}
+{{- end}}
+
+Output Adapter Flags(required):
+  --output-adapter string  Output adapter type (folder, s3, dtrack, interlynk)
+
+  Folder Output Adapter:
+{{- range .Flags}}
+{{- if prefix .Name "out-folder-"}}
+    --{{.Name}} {{.ValueType}}  {{.Usage}}
+{{- end}}
+{{- end}}
+
+  S3 Output Adapter:
+{{- range .Flags}}
+{{- if prefix .Name "out-s3-"}}
+    --{{.Name}} {{.ValueType}}  {{.Usage}}
+{{- end}}
+{{- end}}
+
+  Dependency Track Output Adapter:
+{{- range .Flags}}
+{{- if prefix .Name "out-dtrack-"}}
+    --{{.Name}} {{.ValueType}}  {{.Usage}}
+{{- end}}
+{{- end}}
+
+  Interlynk Output Adapter:
+{{- range .Flags}}
+{{- if prefix .Name "out-interlynk-"}}
+    --{{.Name}} {{.ValueType}}  {{.Usage}}
+{{- end}}
+{{- end}}
+
+Run 'sbommv transfer --guide' for a beginner-friendly guide or visit https://github.com/interlynk-io/sbommv/tree/main/examples for more examples.
+`
+
+	// Set custom help function to render template with funcMap
+	transferCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		// Collect all flags into a slice
+		var flags []FlagData
+		cmd.Flags().VisitAll(func(f *pflag.Flag) {
+			flags = append(flags, FlagData{
+				Name:      f.Name,
+				Shorthand: f.Shorthand,
+				Usage:     f.Usage,
+				ValueType: f.Value.Type(),
+			})
+		})
+
+		// Data for template
+		data := struct {
+			Command *cobra.Command
+			Flags   []FlagData
+		}{
+			Command: cmd,
+			Flags:   flags,
+		}
+
+		// Parse and render template
+		tmpl, err := template.New("help").Funcs(funcMap).Parse(helpTemplate)
+		if err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Error parsing help template: %v\n", err)
+			return
+		}
+
+		// Execute template with data
+		if err := tmpl.Execute(cmd.OutOrStdout(), data); err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Error rendering help template: %v\n", err)
+		}
+	})
 }
 
 // registerAdapterFlags dynamically adds flags for the selected adapters after flag parsing


### PR DESCRIPTION
This PR adds the following changes:
- It improves the help message for the `sbommv transfer` command to make it clearer and easier to understand the respective adapters and it;s flags. Earlier it was like a chaos, all flags placed in one section, which can confused user.
  - It Groups options into categories: General, Input (GitHub, Folder, S3), and Output (Folder, S3, Dependency Track, Interlynk).
  - Under Input categories, all input adapters are placed with a detail of their respective flags.
- It also adds `--guide` flag for beginners, `sbommv transfer --guide` 

It looks like:
```bash
go run main.go transfer -h

Transfer SBOMs between systems

Usage:
  sbommv transfer [flags]

Examples:
  # GitHub (release) to Folder
  sbommv transfer --input-adapter=github --in-github-url="https://github.com/interlynk-io/sbomqs" --in-github-method=release \
                  --output-adapter=folder --out-folder-path="temp"

  # Folder to S3
  sbommv transfer --input-adapter=folder --in-folder-path="temp" --in-folder-recursive \
                  --output-adapter=s3 --out-s3-bucket-name="demo-test-sbom" --out-s3-prefix="sboms" --out-s3-region="us-east-1"

  # S3 to Dependency Track
  sbommv transfer --input-adapter=s3 --in-s3-bucket-name="source-test-sbom" --in-s3-prefix="dropwizard" --in-s3-region="us-east-1" \
                  --output-adapter=dtrack --out-dtrack-url="http://localhost:8081" --out-dtrack-project-name="my-project"

  # GitHub (api) to Interlynk
  sbommv transfer --input-adapter=github --in-github-url="https://github.com/interlynk-io/sbomqs" \
                  --output-adapter=interlynk --out-interlynk-url="http://localhost:3000/lynkapi" --out-interlynk-project-name="sbomqs"

General Flags:
  -d, --daemon  Enable daemon mode
  -D, --debug  Enable debug logging
  --dry-run  Simulate transfer without executing
  -h, --help  help for transfer
  --overwrite  Overwrite existing SBOMs at destination
  --processing-mode string  Processing strategy (sequential, parallel)

Input Adapter Flags(required):
  --input-adapter string  Input adapter type (github, folder, s3)

  GitHub Input Adapter:
    --in-github-branch string  Github repository branch
    --in-github-exclude-repos stringSlice  Exclude these repositories e.g sbomqs,sbomasm
    --in-github-include-repos stringSlice  Include only these repositories e.g sbomqs,sbomasm
    --in-github-method string  GitHub method: release, api, or tool
    --in-github-url string  GitHub organization or repository URL
    --in-github-version string  github repo version

  Folder Input Adapter(required):
    --in-folder-path string  Folder path
    --in-folder-recursive   Folder recurssive (default: false)

  S3 Input Adapter:

Output Adapter Flags(required):
  --output-adapter string  Output adapter type (folder, s3, dtrack, interlynk)

  Folder Output Adapter:
    --out-folder-path string  The folder where SBOMs should be stored
    --out-folder-processing-mode string  Folder processing mode (sequential/parallel)

  S3 Output Adapter:

  Dependency Track Output Adapter:
    --out-dtrack-project-name string  Project name to upload SBOMs to
    --out-dtrack-project-version string  Project version (default: latest)
    --out-dtrack-url string  Dependency Track API URL

  Interlynk Output Adapter:
    --out-interlynk-project-env string  Interlynk Project Environment
    --out-interlynk-project-name string  Interlynk Project Name
    --out-interlynk-url string  Interlynk API URL

Run 'sbommv transfer --guide' for a beginner-friendly guide or visit https://github.com/interlynk-io/sbommv/tree/main/examples for more examples.


```


The o/p of command: `sbommv transfer --guide`:
```bash
sbommv  transfer --guide
Welcome to sbommv! The `transfer` command moves Software Bill of Materials (SBOMs) from one place to another.

Get started in 3 steps:
1. Choose an input source (where SBOMs come from):
   - GitHub: Fetch from repositories (e.g., a project’s code).
   - Folder: Use SBOM files from a local directory.
   - S3: Pull SBOMs from an AWS S3 bucket.
2. Choose an output destination (where SBOMs go):
   - Folder: Save to a local directory.
   - S3: Upload to an AWS S3 bucket.
   - Dependency Track: Send to a Dependency Track server.
   - Interlynk: Upload to the Interlynk platform.
3. Run a command like:
   sbommv transfer --input-adapter=folder --in-folder-path="sboms" --output-adapter=s3 --out-s3-bucket-name="my-bucket" --out-s3-prefix="sboms"
   sbommv transfer --input-adapter=github --in-github-url="https://github.com/interlynk-io/sbomqs" --output-adapter=dtrack --out-dtrack-url="http://localhost:8081"

For more details and options, run `sbommv transfer --help`.
Explore examples at https://github.com/interlynk-io/sbommv/tree/main/examples.

```
The S3 Input and S3 Output will be automatically parsed as the S3 Adapter PR get's merged.