### PR TITLE
fix: enable cgo env

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,6 +3,8 @@ version: 2
 
 env:
   - GO111MODULE=on
+  - CGO_ENABLED=1
+
 
 before:
   hooks:
@@ -30,7 +32,7 @@ builds:
     ldflags:
       - "{{ .Env.LDFLAGS }}"
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
 
 nfpms:
   - id: sbommv

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 
 # Build for multiple architectures
 ARG TARGETOS TARGETARCH
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -o sbommv .
+RUN CGO_ENABLED=1 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -o sbommv .
 
 RUN chmod +x sbommv
 

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ test: generate
 
 .PHONY: build
 build:
-	CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/sbommv main.go
+	CGO_ENABLED=1 go build -trimpath -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/sbommv main.go
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
This PR updates the following changes:
- It enables `CGO_ENABLED`, which is required for build.