### PR TITLE
Fix/interlynk options

### DIFF
--- a/cmd/transfer_test.go
+++ b/cmd/transfer_test.go
@@ -40,14 +40,6 @@ func SBOMFolderPath() string {
 	return defaultSBOMFolder
 }
 
-// mockGitHubRelease mimics a GitHub API release response
-type mockGitHubRelease struct {
-	Assets []struct {
-		Name               string `json:"name"`
-		BrowserDownloadURL string `json:"browser_download_url"`
-	} `json:"assets"`
-}
-
 // upload from github_api to dtrack (without providing project name and project version)
 func TestUploadGithubAPIToDTrack(t *testing.T) {
 	folderPath := SBOMFolderPath()
@@ -178,10 +170,10 @@ func TestUploadGithubAPIToDTrack(t *testing.T) {
 	assert.Contains(t, outBuf.String(), "Initializing SBOMs uploading to Dependency-Track sequentially", "Expected upload start")
 
 	assert.Contains(t, outBuf.String(), "New project will be created", "Expected project creation")
-	assert.Contains(t, outBuf.String(), `{"name": "interlynk-io-sbomqs-latest-dependency-graph-sbom.json", "version": "latest"}`, "Expected new project details")
+	assert.Contains(t, outBuf.String(), `{"name": "interlynk-io/sbomqs-latest-dependency-graph-sbom.json", "version": "latest"}`, "Expected new project details")
 
 	assert.Contains(t, outBuf.String(), "Processing Uploading SBOMs", "Expected successful upload completion")
-	assert.Contains(t, outBuf.String(), `{"project": "interlynk-io-sbomqs-latest-dependency-graph-sbom.json", "version": "latest"}`, "Expected project upload processsing")
+	assert.Contains(t, outBuf.String(), `{"project": "interlynk-io/sbomqs-latest-dependency-graph-sbom.json", "version": "latest"}`, "Expected project upload processsing")
 
 	assert.Contains(t, outBuf.String(), "Fetched SBOM successfully", "Expected fetch success")
 	assert.Contains(t, outBuf.String(), "New project will be created", "Expected project creation")

--- a/examples/github_interlynk_examples.md
+++ b/examples/github_interlynk_examples.md
@@ -39,8 +39,13 @@ Now let's dive into various use cases and examples.
 #### Fetch SBOMs from the latest release of a Github repository and upload to Interlynk
 
 ```bash
-sbommv transfer --input-adapter=github --in-github-url="https://github.com/sigstore/cosign" \
-                --in-github-method=release --output-adapter=interlynk --out-interlynk-url="https://api.interlynk.io/lynkapi" --dry-run
+sbommv transfer \
+--input-adapter=github \
+--in-github-url="https://github.com/sigstore/cosign" \
+--in-github-method=release \
+--output-adapter=interlynk \
+--out-interlynk-url="https://api.interlynk.io/lynkapi" \
+--dry-run
 ```
 
 - **What this does**:
@@ -52,22 +57,33 @@ sbommv transfer --input-adapter=github --in-github-url="https://github.com/sigst
   - remove the `dry-run` flag, to process with uploading part.
 
 ```bash
-sbommv transfer --input-adapter=github --in-github-url="https://github.com/sigstore/cosign" \
-                --in-github-method=release --output-adapter=interlynk --out-interlynk-url="https://api.interlynk.io/lynkapi"
+sbommv transfer \
+--input-adapter=github \
+--in-github-url="https://github.com/sigstore/cosign" \
+--in-github-method=release \
+--output-adapter=interlynk --out-interlynk-url="https://api.interlynk.io/lynkapi"
 ```
+
+- **What this does**:
+  - Fetches SBOMs from the latest release of the repository `sigstore/cosign`
+  - And upload the SBOMs on Interlynk with project name `sigstore/cosign`
+  - And under this `sigtore/cosign` all the SBOMs are uploaded.
 
 ### 1.2 GitHub API Method (Dependency Graph): default method
 
 #### Fetch SBOMs using the GitHub API and upload to Interlynk
 
 ```bash
-sbommv transfer --input-adapter=github --in-github-url="https://github.com/sigstore/cosign" \
-                 --output-adapter=interlynk --out-interlynk-url="https://api.interlynk.io/lynkapi"
+sbommv transfer \
+--input-adapter=github \
+--in-github-url="https://github.com/sigstore/cosign" \
+--output-adapter=interlynk \
+--out-interlynk-url="https://api.interlynk.io/lynkapi"
 ```
 
 - **What this does**:
   - Fetches SBOMs from GitHub’s dependency graph API for the repository `sigstore/cosign`
-  - Uploads them to Interlynk
+  - Uploads them to Interlynk with a project name `sigstore/cosign`
 
 **NOTE**:
 
@@ -78,8 +94,12 @@ sbommv transfer --input-adapter=github --in-github-url="https://github.com/sigst
 #### Clone the repo, generate an SBOM using Syft, and upload it to Interlynk.
 
 ```bash
-sbommv transfer --input-adapter=github --in-github-url="https://github.com/sigstore/cosign" \
-                --in-github-method=tool --output-adapter=interlynk --out-interlynk-url="https://api.interlynk.io/lynkapi"
+sbommv transfer \
+--input-adapter=github \
+--in-github-url="https://github.com/sigstore/cosign" \
+--in-github-method=tool \
+--output-adapter=interlynk \
+--out-interlynk-url="https://api.interlynk.io/lynkapi"
 ```
 
 - **What this does**:
@@ -94,9 +114,12 @@ sbommv transfer --input-adapter=github --in-github-url="https://github.com/sigst
 #### 1.3.1 Fetch SBOMs for a Specific GitHub Branch (Tool Method Only)
 
 ```bash
-sbommv transfer --input-adapter=github --in-github-url="https://github.com/sigstore/cosign" \
-                --in-github-method=tool --in-github-branch="main" \
-                --output-adapter=interlynk --out-interlynk-url="https://api.interlynk.io/lynkapi"
+sbommv transfer \
+--input-adapter=github \
+--in-github-url="https://github.com/sigstore/cosign" \
+--in-github-method=tool --in-github-branch="main" \
+--output-adapter=interlynk \
+--out-interlynk-url="https://api.interlynk.io/lynkapi"
 ```
 
 - **What this does**:
@@ -111,8 +134,12 @@ sbommv transfer --input-adapter=github --in-github-url="https://github.com/sigst
 ## 2. Using Dry-Run Mode (No Upload, Just Simulation)
 
 ```bash
-sbommv transfer --input-adapter=github --in-github-url="https://github.com/sigstore/cosign" \
-                --output-adapter=interlynk --out-interlynk-url="https://api.interlynk.io/lynkapi" --dry-run
+sbommv transfer \
+--input-adapter=github \
+--in-github-url="https://github.com/sigstore/cosign" \
+--output-adapter=interlynk \
+--out-interlynk-url="https://api.interlynk.io/lynkapi" \
+--dry-run
 ```
 
 - **What this does**:
@@ -131,9 +158,13 @@ sbommv transfer --input-adapter=github --in-github-url="https://github.com/sigst
 #### 3.1.1 Github Release Method
 
 ```bash
-sbommv transfer --input-adapter=github --in-github-url="https://github.com/sigstore" \
-                --in-github-method=release --in-github-include-repos=cosign,rekor \
-                --output-adapter=interlynk --out-interlynk-url="https://api.interlynk.io/lynkapi"
+sbommv transfer \
+--input-adapter=github \
+--in-github-url="https://github.com/sigstore" \
+--in-github-method=release \
+--in-github-include-repos=cosign,rekor \
+--output-adapter=interlynk \
+--out-interlynk-url="https://api.interlynk.io/lynkapi"
 ```
 
 - **What this does**:
@@ -148,9 +179,12 @@ sbommv transfer --input-adapter=github --in-github-url="https://github.com/sigst
 #### 3.1.2 Github API Method
 
 ```bash
-sbommv transfer --input-adapter=github --in-github-url="https://github.com/sigstore" \
-                --in-github-include-repos=cosign,rekor \
-                --output-adapter=interlynk --out-interlynk-url="https://api.interlynk.io/lynkapi"
+sbommv transfer \
+--input-adapter=github \
+--in-github-url="https://github.com/sigstore" \
+--in-github-include-repos=cosign,rekor \
+--output-adapter=interlynk \
+--out-interlynk-url="https://api.interlynk.io/lynkapi"
 ```
 
 - **What this does**:
@@ -161,24 +195,30 @@ sbommv transfer --input-adapter=github --in-github-url="https://github.com/sigst
 #### 3.1.3 Github Tool Method
 
 ```bash
-sbommv transfer --input-adapter=github --in-github-url="https://github.com/sigstore" \
-                --in-github-method=tool --in-github-include-repos=cosign,rekor \
-                --output-adapter=interlynk --out-interlynk-url="https://api.interlynk.io/lynkapi"
+sbommv transfer \
+--input-adapter=github \
+--in-github-url="https://github.com/sigstore" \
+--in-github-method=tool --in-github-include-repos=cosign,rekor \
+--output-adapter=interlynk \
+--out-interlynk-url="https://api.interlynk.io/lynkapi"
 ```
 
 - **What this does**:
   - Fetches SBOMs only from `cosign` and `rekor` repositories in the `sigstore` organization.
   - Uploads them as separate projects in Interlynk.
-  - `cosign`, `rekor` SBOMs will be uploaded to `sigstore/cosign` and `sigstore/reko` respectively.
+  - `cosign`, `rekor` SBOMs will be uploaded to `sigstore/cosign` and `sigstore/rekor` respectively.
 
 ### 3.2 Exclude Certain Repositories from an Organization
 
 #### 3.2.1  Github Release Method
 
 ```bash
-sbommv transfer --input-adapter=github --in-github-url="https://github.com/sigstore" \
-                --in-github-method=release --in-github-exclude-repos=docs \
-                --output-adapter=interlynk --out-interlynk-url="https://api.interlynk.io/lynkapi"
+sbommv transfer \
+--input-adapter=github \
+--in-github-url="https://github.com/sigstore" \
+--in-github-method=release --in-github-exclude-repos=docs \
+--output-adapter=interlynk \
+--out-interlynk-url="https://api.interlynk.io/lynkapi"
 ```
 
 - **What this does**:
@@ -189,9 +229,12 @@ sbommv transfer --input-adapter=github --in-github-url="https://github.com/sigst
 #### 3.2.2 Github API Method
 
 ```bash
-sbommv transfer --input-adapter=github --in-github-url="https://github.com/sigstore" \
-                --in-github-exclude-repos=docs \
-                --output-adapter=interlynk --out-interlynk-url="https://api.interlynk.io/lynkapi"
+sbommv transfer \
+--input-adapter=github \
+--in-github-url="https://github.com/sigstore" \
+--in-github-exclude-repos=docs \
+--output-adapter=interlynk \
+--out-interlynk-url="https://api.interlynk.io/lynkapi"
 ```
 
 - **What this does**:
@@ -202,27 +245,18 @@ sbommv transfer --input-adapter=github --in-github-url="https://github.com/sigst
 #### 3.2.3 Github Tool Method
 
 ```bash
-sbommv transfer --input-adapter=github --in-github-url="https://github.com/sigstore" \
-                --in-github-method=tool --in-github-exclude-repos=docs \
-                --output-adapter=interlynk --out-interlynk-url="https://api.interlynk.io/lynkapi"
+sbommv transfer \
+--input-adapter=github \
+--in-github-url="https://github.com/sigstore" \
+--in-github-method=tool \
+--in-github-exclude-repos=docs \
+--output-adapter=interlynk \
+--out-interlynk-url="https://api.interlynk.io/lynkapi"
 ```
 
 - **What this does**:
   - Fetches SBOMs from all repositories in `sigstore` except `docs`.
   - Uploads them as separate projects in Interlynk.
-
-## 4. GitHub  → Folder
-
-### Fetch SBOMs from github repo and save it to a folder
-
-```bash
- sbommv transfer --input-adapter=github --in-github-url="https://github.com/sigstore/" --in-github-include-repos=cosign,fulcio,rekor --in-github-method="release" --output-adapter=folder --out-folder-path="temp"
-```
-
-- **What this does**:
-  - Fetches SBOMs from `sigstore` organization for repositories in `cosign`, `fulcio`, and `rekor`.
-  - Save these SBOMs to a folder `temp`.
-  - Under `temp`, seperate sub-dir with name `cosign`, `fulcio` and `rekor` will be created and respective repo SBOMs will be stored there.
 
 ## 4. Continuous Monitoring (Daemon Mode): GitHub → Interlynk
 
@@ -233,9 +267,14 @@ Enable continuous monitoring by adding the `--daemon` or `-d` flag to your comma
 #### 4.1.1 GitHub Release Method (Daemon Mode)
 
 ```bash
-sbommv transfer --input-adapter=github --in-github-url="https://github.com/interlynk-io/sbomqs" \
-                --in-github-method=release --output-adapter=interlynk --out-interlynk-url="https://api.interlynk.io/lynkapi" \
-                --daemon --in-github-poll-interval="60s"
+sbommv transfer \
+--input-adapter=github \
+--in-github-url="https://github.com/interlynk-io/sbomqs" \
+--in-github-method=release \
+--in-github-poll-interval="60s" \
+--output-adapter=interlynk \
+--out-interlynk-url="https://api.interlynk.io/lynkapi" \
+--daemon
 ```
 
 **What this does:**
@@ -243,7 +282,7 @@ sbommv transfer --input-adapter=github --in-github-url="https://github.com/inter
 - Continuously monitors the `interlynk-io/sbomqs` repository for new releases containing SBOM artifacts.
 - Polls every 60 seconds (customizable via `--in-github-poll-interval`).
 - Fetches SBOMs from the GitHub Release page when a new release is detected.
-- Uploads new SBOMs to Interlynk as a project named `interlynk-io/sbomqs-<sbom_file-name>`.
+- Uploads new SBOMs to Interlynk as a project named `interlynk-io/sbomqs`.
 
 **NOTE**:
 
@@ -255,9 +294,13 @@ sbommv transfer --input-adapter=github --in-github-url="https://github.com/inter
 #### 4.1.2 GitHub API Method (Daemon Mode)
 
 ```bash
-sbommv transfer --input-adapter=github --in-github-url="https://github.com/interlynk-io/sbomqs" \
-                --output-adapter=interlynk --out-interlynk-url="https://api.interlynk.io/lynkapi" \
-                --daemon --in-github-poll-interval="24h"
+sbommv transfer \
+--input-adapter=github \
+--in-github-url="https://github.com/interlynk-io/sbomqs" \
+--in-github-poll-interval="24h" \
+--output-adapter=interlynk \
+--out-interlynk-url="https://api.interlynk.io/lynkapi" \
+--daemon
 ```
 
 **What this does:**
@@ -275,9 +318,14 @@ sbommv transfer --input-adapter=github --in-github-url="https://github.com/inter
 #### 4.1.3 GitHub Tool Method (Daemon Mode)
 
 ```bash
-sbommv transfer --input-adapter=github --in-github-url="https://github.com/interlynk-io/sbomqs" \
-                --in-github-method=tool --output-adapter=interlynk --out-interlynk-url="https://api.interlynk.io/lynkapi" \
-                --daemon --in-github-poll-interval="24h"
+sbommv transfer \
+--input-adapter=github \
+--in-github-url="https://github.com/interlynk-io/sbomqs" \
+--in-github-method=tool \
+--in-github-poll-interval="24h" \
+--output-adapter=interlynk \
+--out-interlynk-url="https://api.interlynk.io/lynkapi" \
+--daemon 
 ```
 
 **What this does:**
@@ -298,10 +346,15 @@ sbommv transfer --input-adapter=github --in-github-url="https://github.com/inter
 #### 4.2.1 GitHub Release Method (Daemon Mode)
 
 ```bash
-sbommv transfer --input-adapter=github --in-github-url="https://github.com/interlynk-io" \
-                --in-github-method=release --in-github-include-repos=sbomqs,sbommv \
-                --output-adapter=interlynk --out-interlynk-url="https://api.interlynk.io/lynkapi" \
-                --daemon --in-github-poll-interval="24h"
+sbommv transfer \
+--input-adapter=github \
+--in-github-url="https://github.com/interlynk-io" \
+--in-github-method=release \
+--in-github-include-repos=sbomqs,sbommv \
+--output-adapter=interlynk \
+--out-interlynk-url="https://api.interlynk.io/lynkapi" \
+--daemon \
+--in-github-poll-interval="24h"
 ```
 
 **What this does:**
@@ -309,7 +362,7 @@ sbommv transfer --input-adapter=github --in-github-url="https://github.com/inter
 - Continuously monitors the `sbomqs` and `sbommv` repositories under the `interlynk-io` organization for new releases containing SBOM artifacts.
 - Polls every 24 hours (customizable via `--in-github-poll-interval`).
 - Fetches SBOMs from the GitHub Release pages when new releases are detected.
-- Uploads new SBOMs to Interlynk as projects named `interlynk-io/sbomqs-<sbom-filename` and `interlynk-io/sbommv-<sbom_filename>`.
+- Uploads new SBOMs to Interlynk as projects named `interlynk-io/sbomqs` and `interlynk-io/sbommv`.
 
 **NOTE:**
 
@@ -320,10 +373,15 @@ sbommv transfer --input-adapter=github --in-github-url="https://github.com/inter
 #### 4.2.2 GitHub API Method (Daemon Mode)
 
 ```bash
-sbommv transfer --input-adapter=github --in-github-url="https://github.com/interlynk-io" \
-                --in-github-method=api --in-github-include-repos=sbomqs,sbommv \
-                --output-adapter=interlynk --out-interlynk-url="https://api.interlynk.io/lynkapi" \
-                --daemon --in-github-poll-interval="24h"
+sbommv transfer \
+--input-adapter=github \
+--in-github-url="https://github.com/interlynk-io" \
+--in-github-method=api \
+--in-github-include-repos=sbomqs,sbommv \
+--output-adapter=interlynk \
+--out-interlynk-url="https://api.interlynk.io/lynkapi" \
+--daemon \
+--in-github-poll-interval="24h"
 ```
 
 **What this does:**
@@ -331,7 +389,7 @@ sbommv transfer --input-adapter=github --in-github-url="https://github.com/inter
 - Continuously monitors the `sbomqs` and `sbommv` repositories under the `interlynk-io` organization for Dependency Graph SBOM updates.
 - Polls every 24 hours (customizable via `--in-github-poll-interval`).
 - Fetches SBOMs using GitHub’s Dependency Graph API when updates are detected.
-- Uploads new SBOMs to Interlynk as projects named `interlynk-io/sbomqs-latest-dependency-graph-sbom.json` and `interlynk-io/sbommv-latest-dependency-graph-sbom.json`.
+- Uploads new SBOMs to Interlynk as projects named `interlynk-io/sbomqs` and `interlynk-io/sbommv`.
 
 **NOTE:**
 
@@ -342,10 +400,14 @@ sbommv transfer --input-adapter=github --in-github-url="https://github.com/inter
 #### 4.2.3 GitHub Tool Method (Daemon Mode)
 
 ```bash
-sbommv transfer --input-adapter=github --in-github-url="https://github.com/interlynk-io" \
-                --in-github-method=tool --in-github-include-repos=sbomqs,sbommv \
-                --output-adapter=interlynk --out-interlynk-url="https://api.interlynk.io/lynkapi" \
-                --daemon --in-github-poll-interval="24h"
+sbommv transfer \
+--input-adapter=github \
+--in-github-url="https://github.com/interlynk-io" \
+--in-github-method=tool \
+--in-github-include-repos=sbomqs,sbommv \
+--output-adapter=interlynk \
+--out-interlynk-url="https://api.interlynk.io/lynkapi" \
+--daemon --in-github-poll-interval="24h"
 ```
 
 **What this does:**
@@ -353,7 +415,7 @@ sbommv transfer --input-adapter=github --in-github-url="https://github.com/inter
 - Continuously monitors the `sbomqs` and `sbommv` repositories under the `interlynk-io` organization for new releases containing SBOM artifacts.
 - Polls every 24 hours (customizable via `--in-github-poll-interval`).
 - Clones the repositories and generates SBOMs using Syft when new releases are detected.
-- Uploads new SBOMs to Interlynk as projects named `interlynk-io/sbomqs-latest-syft-generated-sbom.json` and `interlynk-io/sbommv-latest-syft-generated-sbom.json`.
+- Uploads new SBOMs to Interlynk as projects named `interlynk-io/sbomqs` and `interlynk-io/sbommv`.
 
 **NOTE:**
 
@@ -361,41 +423,20 @@ sbommv transfer --input-adapter=github --in-github-url="https://github.com/inter
 - Cache files (e.g., `.sbommv/cache_interlynk_tool.db`) are created per adapter-method combination.
 - To stop the daemon, press Ctrl+C.
 
-## 5. GitHub → Folder
-
-### Fetch SBOMs from GitHub repo and save it to a folder
-
-```bash
-sbommv transfer --input-adapter=github --in-github-url="https://github.com/interlynk-io/" --in-github-include-repos=sbomqs,sbommv --in-github-method="release" --output-adapter=folder --out-folder-path="temp"
-```
-
-- **What this does**:
-  - Fetches SBOMs from the `interlynk-io` organization for repositories `sbomqs` and `sbommv`.
-  - Saves these SBOMs to a folder named `temp`.
-  - Under temp, separate sub-directories named `sbomqs` and `sbommv` will be created, and the respective repo SBOMs will be stored there.
-
-## 6. Folder → Interlynk
-
-### Fetch SBOMs from folder "temp" and upload/push it to Interlynk
-
-```bash
-sbommv transfer --input-adapter=folder --in-folder-path="temp" --in-folder-recursive=true --output-adapter=interlynk --out-interlynk-url="https://api.interlynk.io/lynkapi"
-```
-
-**What this does:**
-
-- Fetches/scans SBOMs from the temp directory for all sub-directories such as `sbomqs` and `sbommv`.
-- Uploads these SBOMs to Interlynk with project IDs `interlynk-io/sbomqs` and `interlynk-io/sbommv`.
-
-## 7. Some More Examples
+## 6. Some More Examples
 
 ### Combine Multiple Flags for Full Customization
 
 ```bash
-sbommv transfer --input-adapter=github --in-github-url="https://github.com/interlynk-io/sbomqs" \
-                --in-github-method=tool --in-github-branch="dev" \
-                --output-adapter=interlynk --out-interlynk-url="https://api.interlynk.io/lynkapi" \
-                --out-interlynk-project-name="sbomqs-dev" --out-interlynk-project-env="development"
+sbommv transfer \
+--input-adapter=github \
+--in-github-url="https://github.com/interlynk-io/sbomqs" \
+--in-github-method=tool \
+--in-github-branch="dev" \
+--output-adapter=interlynk \
+--out-interlynk-url="https://api.interlynk.io/lynkapi" \
+--out-interlynk-project-name="sbomqs-dev" \
+--out-interlynk-project-env="development"
 ```
 
 **What this does:**

--- a/pkg/source/github/iterator.go
+++ b/pkg/source/github/iterator.go
@@ -88,7 +88,7 @@ func (it *GitHubIterator) fetchSBOMFromAPI(ctx tcontext.TransferMetadata) ([]*it
 		Data: sbomData,
 
 		// namespace as owner/repo, where SBOM are present
-		Namespace: fmt.Sprintf("%s-%s", it.client.Owner, it.client.Repo),
+		Namespace: fmt.Sprintf("%s/%s", it.client.Owner, it.client.Repo),
 		Version:   "latest",
 	})
 	logger.LogDebug(ctx.Context, "SBOM successfully fetched using API Method")
@@ -112,7 +112,7 @@ func (it *GitHubIterator) fetchSBOMFromReleases(ctx tcontext.TransferMetadata) (
 				Data: sbomData.Content,
 
 				// namespace as owner/repo, where SBOM are present
-				Namespace: fmt.Sprintf("%s-%s", it.client.Owner, it.client.Repo),
+				Namespace: fmt.Sprintf("%s/%s", it.client.Owner, it.client.Repo),
 				Version:   version,
 			})
 		}
@@ -156,7 +156,7 @@ func (it *GitHubIterator) fetchSBOMFromTool(ctx tcontext.TransferMetadata) ([]*i
 		Data: sbomBytes,
 
 		// namespace as owner/repo, where SBOM are present
-		Namespace: fmt.Sprintf("%s-%s", it.client.Owner, it.client.Repo),
+		Namespace: fmt.Sprintf("%s/%s", it.client.Owner, it.client.Repo),
 		Version:   it.client.Version,
 		Branch:    it.client.Branch,
 	})

--- a/pkg/target/dependencytrack/reporter.go
+++ b/pkg/target/dependencytrack/reporter.go
@@ -65,7 +65,7 @@ func (r *DependencyTrackReporter) DryRun(ctx tcontext.TransferMetadata, iter ite
 
 		sourceAdapter := ctx.Value("source")
 
-		finalProjectName, _ := utils.ConstructProjectName(ctx, r.projectName, r.projectVersion, sbom.Namespace, sbom.Version, sbom.Path, sbom.Data, sourceAdapter.(string))
+		finalProjectName, _ := utils.ConstructDTProjectName(ctx, r.projectName, r.projectVersion, sbom.Namespace, sbom.Version, sbom.Path, sbom.Data, sourceAdapter.(string))
 
 		fmt.Printf("- 📁 Would upload to project '%s' | Format: %s | SpecVersion: %s | Filename: %s\n",
 			finalProjectName, doc.Format, doc.SpecVersion, sbom.Path)

--- a/pkg/target/dependencytrack/uploader.go
+++ b/pkg/target/dependencytrack/uploader.go
@@ -64,7 +64,7 @@ func (u *SequentialUploader) Upload(ctx tcontext.TransferMetadata, config *Depen
 		sourceAdapter := ctx.Value("source")
 
 		// Construct project name and version
-		finalProjectName, _ := utils.ConstructProjectName(ctx, config.ProjectName, config.ProjectVersion, sbom.Namespace, sbom.Version, sbom.Path, sbom.Data, sourceAdapter.(string))
+		finalProjectName, _ := utils.ConstructDTProjectName(ctx, config.ProjectName, config.ProjectVersion, sbom.Namespace, sbom.Version, sbom.Path, sbom.Data, sourceAdapter.(string))
 
 		projectVersion := "latest"
 		if config.ProjectVersion != "" {
@@ -199,7 +199,7 @@ func (u *ParallelUploader) Upload(ctx tcontext.TransferMetadata, config *Depende
 			for sbom := range sbomChan {
 
 				sourceAdapter := ctx.Value("source")
-				finalProjectName, _ := utils.ConstructProjectName(ctx, config.ProjectName, config.ProjectVersion, sbom.Namespace, sbom.Version, sbom.Path, sbom.Data, sourceAdapter.(string))
+				finalProjectName, _ := utils.ConstructDTProjectName(ctx, config.ProjectName, config.ProjectVersion, sbom.Namespace, sbom.Version, sbom.Path, sbom.Data, sourceAdapter.(string))
 
 				projectVersion := "latest"
 				if config.ProjectVersion != "" {

--- a/pkg/target/folder/reporter.go
+++ b/pkg/target/folder/reporter.go
@@ -48,17 +48,11 @@ func (r *FolderOutputReporter) DryRun(ctx tcontext.TransferMetadata, iter iterat
 			return err
 		}
 
-		namespace := filepath.Base(sbom.Namespace)
-		if namespace == "" {
-			namespace = fmt.Sprintf("sbom_%s.json", uuid.New().String())
-		}
+		outputFolder := r.folderPath
 
-		// outputPath := filepath.Join(r.folderPath, namespace)
-		outputPath := r.folderPath
-
-		outputFile := filepath.Join(outputPath, sbom.Path)
+		outputFile := filepath.Join(outputFolder, sbom.Path)
 		if sbom.Path == "" {
-			outputFile = filepath.Join(outputPath, fmt.Sprintf("%s.sbom.json", uuid.New().String()))
+			outputFile = filepath.Join(outputFolder, fmt.Sprintf("%s.sbom.json", uuid.New().String()))
 		}
 
 		fmt.Printf("- 📂 Would write: %s\n", outputFile)

--- a/pkg/target/folder/uploader.go
+++ b/pkg/target/folder/uploader.go
@@ -25,7 +25,6 @@ import (
 	"github.com/interlynk-io/sbommv/pkg/logger"
 	"github.com/interlynk-io/sbommv/pkg/tcontext"
 	"github.com/interlynk-io/sbommv/pkg/types"
-	"github.com/interlynk-io/sbommv/pkg/utils"
 )
 
 type SBOMUploader interface {
@@ -65,21 +64,7 @@ func (u *SequentialUploader) Upload(ctx tcontext.TransferMetadata, config *Folde
 			return err
 		}
 
-		sourceAdapter := ctx.Value("source")
-		destinationAdapter := ctx.Value("destination")
-
-		var finalProjectName string
-
-		// if the source adapter is local folder cloud storage(s3), and the o/p adapter is local folder or cloud storage(s3),
-		// use the SBOM file name as the project name instead of primary comp and version
-		// because at the end they have to save the SBOM file as it is.
-		if sourceAdapter.(string) == "folder" && destinationAdapter.(string) == "folder" || sourceAdapter.(string) == "s3" && destinationAdapter.(string) == "folder" {
-			finalProjectName = sbom.Path
-		} else {
-			finalProjectName, _ = utils.ConstructProjectName(ctx, "", "", sbom.Namespace, sbom.Version, sbom.Path, sbom.Data, sourceAdapter.(string))
-		}
-
-		outputFile := filepath.Join(outputDir, finalProjectName)
+		outputFile := filepath.Join(outputDir, sbom.Path)
 		if sbom.Path == "" {
 			outputFile = filepath.Join(outputDir, fmt.Sprintf("%s.sbom.json", uuid.New().String()))
 		}

--- a/pkg/target/interlynk/adapter.go
+++ b/pkg/target/interlynk/adapter.go
@@ -123,7 +123,6 @@ func (i *InterlynkAdapter) ParseAndValidateParams(cmd *cobra.Command) error {
 	i.ProjectName = projectName
 	i.ProjectEnv = projectEnv
 	i.ApiKey = token
-	// i.settings = types.UploadSettings{ProcessingMode: types.UploadMode(i.ProcessingMode)}
 	i.settings = types.UploadSettings{ProcessingMode: types.UploadMode(types.UploadSequential)}
 
 	logger.LogDebug(cmd.Context(), "Interlynk parameters validated and assigned",
@@ -213,17 +212,7 @@ func (i *InterlynkAdapter) uploadSequential(ctx tcontext.TransferMetadata, sboms
 
 		sourceAdapter := ctx.Value("source")
 
-		finalProjectName, _ := utils.ConstructProjectName(ctx, client.ProjectName, client.ProjectVersion, sbom.Namespace, sbom.Version, sbom.Path, sbom.Data, sourceAdapter.(string))
-
-		// if projectName == "" {
-		// 	// THIS CASE OCCURS WHEN SBOM IS NOT IN JSON FORMAT
-		// 	// when a JSON SBOM has empty primary comp and version, use the file name as project name
-		// 	projectName = filepath.Base(sbom.Path)
-		// 	projectName = projectName[:len(projectName)-len(filepath.Ext(projectName))]
-		// 	projectVersion = "latest"
-		// }
-		// finalProjectName := fmt.Sprintf("%s-%s", projectName, projectVersion)
-
+		finalProjectName := ConstructInterlynkProjectName(ctx, i.ProjectName, sbom.Namespace, sbom.Path, sbom.Data, sourceAdapter.(string))
 		projectID, projectName, err := client.FindOrCreateProjectGroup(ctx, finalProjectName)
 		if err != nil {
 			logger.LogInfo(ctx.Context, "error", err)
@@ -287,8 +276,7 @@ func (i *InterlynkAdapter) DryRun(ctx tcontext.TransferMetadata, sbomIterator it
 
 		sourceAdapter := ctx.Value("source")
 
-		finalProjectName, _ := utils.ConstructProjectName(ctx, i.ProjectName, i.ProjectVersion, sbom.Namespace, sbom.Version, sbom.Path, sbom.Data, sourceAdapter.(string))
-
+		finalProjectName := ConstructInterlynkProjectName(ctx, i.ProjectName, sbom.Namespace, sbom.Path, sbom.Data, sourceAdapter.(string))
 		projectKey := fmt.Sprintf("%s", finalProjectName)
 		projectSBOMs[projectKey] = append(projectSBOMs[projectKey], doc)
 		totalSBOMs++

--- a/pkg/target/interlynk/adapter.go
+++ b/pkg/target/interlynk/adapter.go
@@ -212,6 +212,7 @@ func (i *InterlynkAdapter) uploadSequential(ctx tcontext.TransferMetadata, sboms
 
 		sourceAdapter := ctx.Value("source")
 
+		fmt.Println("++++ sbom.Namespace: ", sbom.Namespace)
 		finalProjectName := ConstructInterlynkProjectName(ctx, i.ProjectName, sbom.Namespace, sbom.Path, sbom.Data, sourceAdapter.(string))
 		projectID, projectName, err := client.FindOrCreateProjectGroup(ctx, finalProjectName)
 		if err != nil {

--- a/pkg/target/interlynk/client.go
+++ b/pkg/target/interlynk/client.go
@@ -101,28 +101,28 @@ func (c *Client) FindOrCreateProjectGroup(ctx tcontext.TransferMetadata, finalPr
 
 	env := c.ProjectEnv
 
-	projectID, err := c.FindProjectGroup(ctx, finalProjectName, env)
+	envID, err := c.FindProjectGroup(ctx, finalProjectName, env)
 	if err != nil {
 		// create project if the project is not present in the interlynk
-		projectID, err = c.CreateProjectGroup(ctx, finalProjectName, env)
+		envID, err = c.CreateProjectGroup(ctx, finalProjectName, env)
 		if err != nil {
 			return "", "", fmt.Errorf("failed to create project: %s on env %s ", finalProjectName, env)
 		}
 	}
 
-	return projectID, finalProjectName, nil
+	return envID, finalProjectName, nil
 }
 
 // UploadSBOM uploads a single SBOM from memory to Interlynk
-func (c *Client) UploadSBOM(ctx tcontext.TransferMetadata, projectID string, sbomData []byte) error {
-	logger.LogDebug(ctx.Context, "Uploading SBOM", "projectID", projectID, "data size", len(sbomData))
+func (c *Client) UploadSBOM(ctx tcontext.TransferMetadata, envID string, sbomData []byte) error {
+	logger.LogDebug(ctx.Context, "Uploading SBOM", "projectID", envID, "data size", len(sbomData))
 
 	if len(sbomData) == 0 {
 		return fmt.Errorf("SBOM data is empty")
 	}
 
 	// Create a context-aware request with appropriate timeout
-	req, err := c.createUploadRequest(ctx, projectID, sbomData)
+	req, err := c.createUploadRequest(ctx, envID, sbomData)
 	if err != nil {
 		return fmt.Errorf("preparing request: %w", err)
 	}

--- a/pkg/target/interlynk/utils.go
+++ b/pkg/target/interlynk/utils.go
@@ -95,10 +95,6 @@ func ConstructInterlynkProjectName(ctx tcontext.TransferMetadata, extProjectName
 
 	if source == "github" {
 		logger.LogDebug(ctx.Context, "Source is a github")
-
-		if strings.Contains(ownerAndGithubRepoName, "-") {
-			return strings.Replace(ownerAndGithubRepoName, "-", "/", 1)
-		}
 		return ownerAndGithubRepoName
 	}
 

--- a/pkg/target/interlynk/utils.go
+++ b/pkg/target/interlynk/utils.go
@@ -21,6 +21,9 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/interlynk-io/sbommv/pkg/logger"
+	"github.com/interlynk-io/sbommv/pkg/sbom"
+	"github.com/interlynk-io/sbommv/pkg/source"
 	"github.com/interlynk-io/sbommv/pkg/tcontext"
 )
 
@@ -80,18 +83,46 @@ func formatSetToString(formatSet map[string]struct{}) string {
 	return strings.Join(formats, ", ")
 }
 
-func getExplicitProjectVersion(ctx tcontext.TransferMetadata, providedProjectName string, providedProjectVersion string) (string, string) {
-	if providedProjectVersion == "" {
-		return providedProjectName, "latest"
+// ConstructInterlynkProjectName return project name, in a way that if externally project name is provided, then return it.
+// otherwise depends on source. If sboms fetched from github source, then return project name as <organization>/<repo>
+// for remaining sources like folder, s3, etc. Return their primary component name + it's version, so unique project created for each SBOM file.
+func ConstructInterlynkProjectName(ctx tcontext.TransferMetadata, extProjectName, ownerAndGithubRepoName, sbomPath string, SbomData []byte, source string) string {
+	logger.LogDebug(ctx.Context, "Constructing Project Name", "providedProjectName", extProjectName, "ownerAndGithubRepoName", ownerAndGithubRepoName, "source", source, "assetpath", sbomPath)
+
+	if extProjectName != "" {
+		return extProjectName
 	}
 
-	return providedProjectName, providedProjectVersion
+	if source == "github" {
+		logger.LogDebug(ctx.Context, "Source is a github")
+
+		if strings.Contains(ownerAndGithubRepoName, "-") {
+			return strings.Replace(ownerAndGithubRepoName, "-", "/", 1)
+		}
+		return ownerAndGithubRepoName
+	}
+
+	// if source other than github, then naming would be different
+	return GetProjectNameAndVersion(ctx, SbomData, sbomPath)
 }
 
-func getImplicitProjectVersion(ctx tcontext.TransferMetadata, providedProjectName string, providedProjectVersion string) (string, string) {
-	if providedProjectVersion == "" {
-		return providedProjectName, "unknown"
+// construct project name from it's primary comp name and it's version by reading sbom content
+func GetProjectNameAndVersion(ctx tcontext.TransferMetadata, content []byte, assetPath string) string {
+	// ONLY APPLICABLE FOR JSON FILE FORMAT SBOM
+	if !source.IsSBOMJSONFormat(content) {
+		logger.LogInfo(ctx.Context, "SBOM File Format is not in JSON format")
+		return ""
 	}
 
-	return providedProjectName, providedProjectVersion
+	logger.LogDebug(ctx.Context, "SBOM File Format is in JSON format")
+	primaryComp := sbom.ExtractPrimaryComponentName(content)
+	logger.LogDebug(ctx.Context, "Project Name and Version", "name", primaryComp.Name, "version", primaryComp.Version)
+
+	if primaryComp.Name != "" && primaryComp.Version != "" {
+		return primaryComp.Name + "-" + primaryComp.Version
+	} else if primaryComp.Version == "" {
+		return primaryComp.Name
+	} else {
+		return assetPath
+	}
 }

--- a/pkg/target/s3/uploader.go
+++ b/pkg/target/s3/uploader.go
@@ -27,7 +27,6 @@ import (
 	"github.com/interlynk-io/sbommv/pkg/iterator"
 	"github.com/interlynk-io/sbommv/pkg/logger"
 	"github.com/interlynk-io/sbommv/pkg/tcontext"
-	"github.com/interlynk-io/sbommv/pkg/utils"
 )
 
 type SBOMUploader interface {
@@ -86,10 +85,10 @@ func (u *S3ParallelUploader) Upload(ctx tcontext.TransferMetadata, config *S3Con
 			defer wg.Done()
 			defer func() { <-semaphore }()
 
-			sourceAdapter := ctx.Value("source")
-			finalProjectName, _ := utils.ConstructProjectName(ctx, "", "", sbom.Namespace, sbom.Version, sbom.Path, sbom.Data, sourceAdapter.(string))
-
-			key := filepath.Join(prefix, finalProjectName)
+			// sourceAdapter := ctx.Value("source")
+			// finalProjectName, _ := utils.ConstructProjectName(ctx, "", "", sbom.Namespace, sbom.Version, sbom.Path, sbom.Data, sourceAdapter.(string))
+			fileName := sbom.Path
+			key := filepath.Join(prefix, fileName)
 
 			// Upload to S3
 			_, err := client.PutObject(ctx.Context, &s3.PutObjectInput{
@@ -107,7 +106,7 @@ func (u *S3ParallelUploader) Upload(ctx tcontext.TransferMetadata, config *S3Con
 			}
 			successfullyUploaded++
 			logger.LogDebug(ctx.Context, "Uploaded SBOM", "bucket", config.BucketName, "key", key, "size", len(sbom.Data))
-			logger.LogInfo(ctx.Context, "upload", "success", true, "bucket", config.BucketName, "prefix", config.Prefix, "filename", finalProjectName)
+			logger.LogInfo(ctx.Context, "upload", "success", true, "bucket", config.BucketName, "prefix", config.Prefix, "filename", fileName)
 
 			mu.Unlock()
 		}(sbom)
@@ -147,19 +146,18 @@ func (u *S3SequentialUploader) Upload(ctx tcontext.TransferMetadata, s3cfg *S3Co
 		if err == io.EOF {
 			break
 		}
-		sourceAdapter := ctx.Value("source")
-		destinationAdapter := ctx.Value("destination")
+		// sourceAdapter := ctx.Value("source")
+		// destinationAdapter := ctx.Value("destination")
 
-		var finalProjectName string
-
-		// if the source adapter is local folder cloud storage(s3), and the o/p adapter is local folder or cloud storage(s3),
-		// use the SBOM file name as the project name instead of primary comp and version
-		// because at the end they have to save the SBOM file as it is.
-		if sourceAdapter.(string) == "folder" && destinationAdapter.(string) == "s3" || sourceAdapter.(string) == "s3" && destinationAdapter.(string) == "s3" {
-			finalProjectName = sbom.Path
-		} else {
-			finalProjectName, _ = utils.ConstructProjectName(ctx, "", "", sbom.Namespace, sbom.Version, sbom.Path, sbom.Data, sourceAdapter.(string))
-		}
+		fileName := sbom.Path
+		// // if the source adapter is local folder cloud storage(s3), and the o/p adapter is local folder or cloud storage(s3),
+		// // use the SBOM file name as the project name instead of primary comp and version
+		// // because at the end they have to save the SBOM file as it is.
+		// if sourceAdapter.(string) == "folder" && destinationAdapter.(string) == "s3" || sourceAdapter.(string) == "s3" && destinationAdapter.(string) == "s3" {
+		// 	finalProjectName = sbom.Path
+		// } else {
+		// 	finalProjectName, _ = utils.ConstructProjectName(ctx, "", "", sbom.Namespace, sbom.Version, sbom.Path, sbom.Data, sourceAdapter.(string))
+		// }
 
 		totalSBOMs++
 		if err != nil {
@@ -167,7 +165,7 @@ func (u *S3SequentialUploader) Upload(ctx tcontext.TransferMetadata, s3cfg *S3Co
 			continue
 		}
 
-		key := filepath.Join(bucketPrefix, finalProjectName)
+		key := filepath.Join(bucketPrefix, fileName)
 
 		// Upload to S3
 		_, err = client.PutObject(ctx.Context, &s3.PutObjectInput{
@@ -182,7 +180,7 @@ func (u *S3SequentialUploader) Upload(ctx tcontext.TransferMetadata, s3cfg *S3Co
 
 		successfullyUploaded++
 		logger.LogDebug(ctx.Context, "Uploaded SBOM", "bucket", s3cfg.BucketName, "key", key, "size", len(sbom.Data))
-		logger.LogInfo(ctx.Context, "upload", "success", true, "bucket", s3cfg.BucketName, "prefix", s3cfg.Prefix, "filename", finalProjectName)
+		logger.LogInfo(ctx.Context, "upload", "success", true, "bucket", s3cfg.BucketName, "prefix", s3cfg.Prefix, "filename", fileName)
 
 	}
 	logger.LogInfo(ctx.Context, "upload", "total", totalSBOMs, "success", successfullyUploaded, "failed", totalSBOMs-successfullyUploaded)

--- a/pkg/utils/project.go
+++ b/pkg/utils/project.go
@@ -21,7 +21,7 @@ import (
 	"github.com/interlynk-io/sbommv/pkg/tcontext"
 )
 
-func ConstructProjectName(ctx tcontext.TransferMetadata, extProjectName, extProjectVersion, ownerRepoGithubName, repoVersion, assetPath string, content []byte, source string) (string, string) {
+func ConstructDTProjectName(ctx tcontext.TransferMetadata, extProjectName, extProjectVersion, ownerRepoGithubName, repoVersion, assetPath string, content []byte, source string) (string, string) {
 	logger.LogDebug(ctx.Context, "Constructing Project Name and Version", "providedProjectName", extProjectName, "providedProjectVersion", extProjectVersion, "ownerRepoName", ownerRepoGithubName, "repoVersion", repoVersion, "source", source, "assetpath", assetPath)
 
 	// user provided project name via flag


### PR DESCRIPTION
This PR adds the following changes:
- Fix the project name of Interlynk, Folder and S3
- For Interlynk,
  - Earlier, the project name has a version. For example, `interlynk-io/sbomqs-latest" 
  - Now it would be  `interlynk-io/sbomqs". 
  - Project name is group, under which versions are there.
- For Folder/S3
  - Now file will be written as a same file name coming from the input adapter
  - Earlier prefix like repo name , version were added.
- Also update sbom namespace.
  -  SBOM Namespace meaning differs from source to source adapters:
  - For github it is `<organization>-<repo>`, i.e `interlynk-io-sbomqs`
  - For folder it's a `<folder>`
  - For S3 it's a `s3cfg.BucketName + "-" + s3cfg.Prefix`
  So, for github sbom namespace, we have replaced `-` by `\`.


Examples for Interlynk:
- Earlier on running below command:
```bash
sbommv transfer \
--input-adapter=github \
--in-github-url="https://github.com/sigstore/cosign" \
--in-github-method="release" \
--output-adapter=interlynk --out-interlynk-project-name="vivek" \
--out-interlynk-url="http://localhost:3000/lynkapi" \
```
The project name assigned as `vivek-latest`. But now on running the same command, the project name is `vivek`.

Similarly, running this command:
```bash
sbommv transfer \
--input-adapter=github \
--in-github-url="https://github.com/sigstore/cosign" \
--in-github-method="release" \
--out-interlynk-url="http://localhost:3000/lynkapi" \
````
The project name assigned as `sigstore/cosign-latest`. But now on running the same command, the project name is `sigstore/cosign`.

Similarly for this:
```bash
 sbommv transfer \
--input-adapter=github \
--in-github-url="https://github.com/sigstore" \
--in-github-method="release" \
--in-github-include-repos=fulcio,rekor \
--output-adapter=interlynk \
--out-interlynk-url="http://localhost:3000/lynkapi"
```
Now, it creates 2 project with name `sigstore/rekor` and `sigstore/fulcio`.

The project represent project group or product itself. All their versioned will be under project. 

Examples For Folder:
On running this below command:
```bash
sbommv transfer \
--input-adapter=github \
--in-github-url="https://github.com/sigstore/cosign" --in-github-method="release" \
--output-adapter=folder \
--out-folder-path="temp" 
```
the file saved with a name, <prefix>-<actual-file-name>, where prefix was `org-repo-version>`, i.e `sigstore-cosign-v2.6.0`
so, final file name for a file(`cosign-linux-pivkey-pkcs11key-amd64_2.6.0_linux_amd64.sbom.json`) will be `temp/sigstore-cosign-v2.6.0-cosign-linux-pivkey-pkcs11key-amd64_2.6.0_linux_amd64.sbom.json`. But now it will be simply as it is the file name, i.e. `cosign-linux-pivkey-pkcs11key-amd64_2.6.0_linux_amd64.sbom.json` 