### PR TITLE
Fix/dtrack project upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $ sbommv transfer --input-adapter=github \
 $ sbommv transfer  --input-adapter=github  \
 --in-github-url="https://github.com/interlynk-io/sbommv"  \
 --output-adapter=dtrack  \
---out-dtrack-url="http://localhost:8081"
+--out-dtrack-url="http://localhost:8080"
 ```
 
 **NOTE**: Make sure dependency-track is running locally, if not, [refer](https://github.com/interlynk-io/sbommv/blob/main/examples/setup_dependency_track.md) for setup.

--- a/cmd/transfer.go
+++ b/cmd/transfer.go
@@ -103,7 +103,7 @@ Examples:
 
   # S3 to Dependency Track
   sbommv transfer --input-adapter=s3 --in-s3-bucket-name="source-test-sbom" --in-s3-prefix="dropwizard" --in-s3-region="us-east-1" \
-                  --output-adapter=dtrack --out-dtrack-url="http://localhost:8081" --out-dtrack-project-name="my-project"
+                  --output-adapter=dtrack --out-dtrack-url="http://localhost:8080" --out-dtrack-project-name="my-project"
 
   # GitHub (api) to Interlynk
   sbommv transfer --input-adapter=github --in-github-url="https://github.com/interlynk-io/sbomqs" \
@@ -258,7 +258,7 @@ Get started in 3 steps:
    - Interlynk: Upload to the Interlynk platform.
 3. Run a command like:
    sbommv transfer --input-adapter=folder --in-folder-path="sboms" --output-adapter=s3 --out-s3-bucket-name="my-bucket" --out-s3-prefix="sboms"
-   sbommv transfer --input-adapter=github --in-github-url="https://github.com/interlynk-io/sbomqs" --output-adapter=dtrack --out-dtrack-url="http://localhost:8081"
+   sbommv transfer --input-adapter=github --in-github-url="https://github.com/interlynk-io/sbomqs" --output-adapter=dtrack --out-dtrack-url="http://localhost:8080"
 
 For more details and options, run ` + "`sbommv transfer --help`" + `.
 Explore examples at https://github.com/interlynk-io/sbommv/tree/main/examples.`)

--- a/examples/github_dtrack_examples.md
+++ b/examples/github_dtrack_examples.md
@@ -31,7 +31,7 @@ sbommv transfer \
 --in-github-url="https://github.com/interlynk-io/sbomqs" \
 --in-github-method=release \
 --output-adapter=dtrack \
---out-dtrack-url="http://localhost:8081"
+--out-dtrack-url="http://localhost:8080"
 ```
 
 - **What this does**:
@@ -53,7 +53,7 @@ sbommv transfer \
 --in-github-url="https://github.com/interlynk-io/sbomqs" \
 --in-github-method=release \               
 --output-adapter=dtrack \                                             
---out-dtrack-url="http://localhost:8081" \   
+--out-dtrack-url="http://localhost:8080" \   
 --out-dtrack-project-name="sbomqs_demo" \        
 --out-dtrack-project-version="v1.0.1"
 ```
@@ -74,7 +74,7 @@ sbommv transfer \
 --input-adapter=github \
 --in-github-url="https://github.com/interlynk-io/sbomqs" \
 --output-adapter=dtrack \
---out-dtrack-url="http://localhost:8081"
+--out-dtrack-url="http://localhost:8080"
 ```
 
 - **What this does**:
@@ -94,7 +94,7 @@ sbommv transfer \
 --in-github-url="https://github.com/interlynk-io/sbomqs" \
 --in-github-method=tool \   
 --output-adapter=dtrack \               
---out-dtrack-url="http://localhost:8081"
+--out-dtrack-url="http://localhost:8080"
 ```
 
 - **What this does**:
@@ -116,7 +116,7 @@ sbommv transfer \
 --in-github-method=tool \
 --in-github-branch="main" \
 --output-adapter=dtrack \
---out-dtrack-url="http://localhost:8081" \
+--out-dtrack-url="http://localhost:8080" \
 ```
 
 - **What this does**:
@@ -136,7 +136,7 @@ sbommv transfer \
 --input-adapter=github \
 --in-github-url="https://github.com/interlynk-io/sbomqs" \
 --output-adapter=dtrack \
---out-dtrack-url="http://localhost:8081" \
+--out-dtrack-url="http://localhost:8080" \
 --dry-run
 ```
 
@@ -162,7 +162,7 @@ sbommv transfer \
 --in-github-method=release \
 --in-github-include-repos=sbomqs,sbommv \
 --output-adapter=dtrack \
---out-dtrack-url="http://localhost:8081"
+--out-dtrack-url="http://localhost:8080"
 ```
 
 - **What this does**:
@@ -182,7 +182,7 @@ sbommv transfer \
 --in-github-url="https://github.com/interlynk-io" \
 --in-github-include-repos=sbomqs,sbommv \
 --output-adapter=dtrack \
---out-dtrack-url="http://localhost:8081"
+--out-dtrack-url="http://localhost:8080"
 ```
 
 - **What this does**:
@@ -199,7 +199,7 @@ sbommv transfer \
 --input-adapter=github \
 --in-github-url="https://github.com/interlynk-io" \
 --in-github-method=tool --in-github-include-repos=sbomqs,sbommv \
---output-adapter=dtrack --out-dtrack-url="http://localhost:8081"
+--output-adapter=dtrack --out-dtrack-url="http://localhost:8080"
 ```
 
 - **What this does**:
@@ -220,7 +220,7 @@ sbommv transfer \
 --in-github-method=release \
 --in-github-exclude-repos=cyclonedx-property-taxonomy,homebrew-interlynk,purl-tools \
 --output-adapter=dtrack \
---out-dtrack-url="http://localhost:8081"
+--out-dtrack-url="http://localhost:8080"
 ```
 
 - **What this does**:
@@ -242,7 +242,7 @@ sbommv transfer \
 --in-github-url="https://github.com/interlynk-io" \
 --in-github-exclude-repos=cyclonedx-property-taxonomy,homebrew-interlynk,purl-tools \
 --output-adapter=dtrack \
---out-dtrack-url="http://localhost:8081"
+--out-dtrack-url="http://localhost:8080"
 ```
 
 - **What this does**:
@@ -265,7 +265,7 @@ sbommv transfer \
 --in-github-method=tool \
 --in-github-exclude-repos=cyclonedx-property-taxonomy,homebrew-interlynk,purl-tools \
 --output-adapter=dtrack \
---out-dtrack-url="http://localhost:8081"
+--out-dtrack-url="http://localhost:8080"
 ```
 
 - **What this does**:
@@ -294,7 +294,7 @@ sbommv transfer \
 --in-github-url="https://github.com/interlynk-io/sbomqs" \
 --in-github-method=release \
 --output-adapter=dtrack \
---out-dtrack-url="http://localhost:8081" \
+--out-dtrack-url="http://localhost:8080" \
 --in-github-poll-interval="60s" \
 --daemon
 ```
@@ -319,7 +319,7 @@ sbommv transfer \
 sbommv transfer \
 --input-adapter=github \
 --in-github-url="https://github.com/interlynk-io/sbomqs" \
---output-adapter=dtrack --out-dtrack-url="http://localhost:8081" \
+--output-adapter=dtrack --out-dtrack-url="http://localhost:8080" \
  --in-github-poll-interval="24hr" \
  --daemon
 ```
@@ -345,7 +345,7 @@ sbommv transfer \
 --in-github-url="https://github.com/interlynk-io/sbomqs" \
 --in-github-method=tool \
 --output-adapter=dtrack \
---out-dtrack-url="http://localhost:8081" \
+--out-dtrack-url="http://localhost:8080" \
 --in-github-poll-interval="24hr" \
 --daemon
 ```
@@ -375,7 +375,7 @@ sbommv transfer \
 --in-github-method=release \
 --in-github-include-repos=sbomqs,sbommv \
 --output-adapter=dtrack \
---out-dtrack-url="http://localhost:8081" \
+--out-dtrack-url="http://localhost:8080" \
 --in-github-poll-interval="24hr" \
 --daemon
 ```
@@ -403,7 +403,7 @@ sbommv transfer \
 --in-github-method=api \
 --in-github-include-repos=sbomqs,sbommv \
 --output-adapter=dtrack \
---out-dtrack-url="http://localhost:8081" \
+--out-dtrack-url="http://localhost:8080" \
 --in-github-poll-interval="24hr" \
 --daemon
 ```
@@ -431,7 +431,7 @@ sbommv transfer \
 --in-github-method=tool \
 --in-github-include-repos=sbomqs,sbommv \
 --output-adapter=dtrack \
---out-dtrack-url="http://localhost:8081" \
+--out-dtrack-url="http://localhost:8080" \
 --in-github-poll-interval="24hr" \
 --daemon
 ```

--- a/examples/s3_dtrack_example.md
+++ b/examples/s3_dtrack_example.md
@@ -40,7 +40,7 @@ sbommv transfer \
 --in-s3-access-key="AKIA..." \
 --in-s3-secret-key="wJalr..." \
 --output-adapter=dtrack \
---out-dtrack-url="http://localhost:8081"
+--out-dtrack-url="http://localhost:8080"
 ```
 
 **What this does**:
@@ -61,7 +61,7 @@ sbommv transfer \
 --in-s3-secret-key="wJalr..." \
 --processing-mode="parallel" \
 --output-adapter=dtrack \
---out-dtrack-url="http://localhost:8081"
+--out-dtrack-url="http://localhost:8080"
 ```
 
 **What this does**:
@@ -84,7 +84,7 @@ sbommv transfer \
 --in-s3-access-key="AKIA..." \
 --in-s3-secret-key="wJalr..." \
 --output-adapter=dtrack \
---out-dtrack-url="http://localhost:8081" \
+--out-dtrack-url="http://localhost:8080" \
 --dry-run
 ```
 
@@ -100,7 +100,7 @@ sbommv transfer \
 --in-s3-secret-key="wJalr..." \
 --in-s3-processing-mode="parallel" \
 --output-adapter=dtrack \
---out-dtrack-url="http://localhost:8081" \
+--out-dtrack-url="http://localhost:8080" \
 --dry-run
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/interlynk-io/sbommv
 go 1.25.0
 
 require (
-	github.com/DependencyTrack/client-go v0.18.0
+	github.com/DependencyTrack/client-go v0.19.0
 	github.com/aws/aws-sdk-go-v2 v1.41.4
 	github.com/aws/aws-sdk-go-v2/config v1.32.12
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.12

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEK
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/CycloneDX/cyclonedx-go v0.10.0 h1:7xyklU7YD+CUyGzSFIARG18NYLsKVn4QFg04qSsu+7Y=
 github.com/CycloneDX/cyclonedx-go v0.10.0/go.mod h1:vUvbCXQsEm48OI6oOlanxstwNByXjCZ2wuleUlwGEO8=
-github.com/DependencyTrack/client-go v0.18.0 h1:HXOUuqKaxIIiksYzJTM6ltuqebxjUW0kFSbPsGSWX1Q=
-github.com/DependencyTrack/client-go v0.18.0/go.mod h1:T5iPG+foFcv6Bn5bTNbjywbmm+gwku4I1MuQWA77sR8=
+github.com/DependencyTrack/client-go v0.19.0 h1:BU1opGs9DEtsdS51a2TqdRyp3vqpHM+/57YKen4ju00=
+github.com/DependencyTrack/client-go v0.19.0/go.mod h1:T5iPG+foFcv6Bn5bTNbjywbmm+gwku4I1MuQWA77sR8=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/anchore/go-struct-converter v0.1.0 h1:2rDRssAl6mgKBSLNiVCMADgZRhoqtw9dedlWa0OhD30=

--- a/pkg/target/dependencytrack/adapter.go
+++ b/pkg/target/dependencytrack/adapter.go
@@ -125,7 +125,10 @@ func (d *DependencyTrackAdapter) ParseAndValidateParams(cmd *cobra.Command) erro
 	d.Config = cfg
 
 	// Initialize the DependencyTrack client
-	client := NewDependencyTrackClient(cfg)
+	client, err := NewDependencyTrackClient(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to initialize Dependency-Track client: %w", err)
+	}
 	d.client = client
 	d.Uploader = uploader
 

--- a/pkg/target/dependencytrack/client.go
+++ b/pkg/target/dependencytrack/client.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"strings"
 	"time"
 
 	dtrack "github.com/DependencyTrack/client-go"
@@ -29,7 +30,7 @@ type DependencyTrackClient struct {
 	Client *dtrack.Client
 }
 
-func NewDependencyTrackClient(config *DependencyTrackConfig) *DependencyTrackClient {
+func NewDependencyTrackClient(config *DependencyTrackConfig) (*DependencyTrackClient, error) {
 	client, err := dtrack.NewClient(
 		config.APIURL,
 		dtrack.WithAPIKey(config.APIKey),
@@ -37,9 +38,16 @@ func NewDependencyTrackClient(config *DependencyTrackConfig) *DependencyTrackCli
 	)
 	if err != nil {
 		logger.LogError(context.Background(), err, "Failed to create Dependency-Track client")
+
+		// Provide a more helpful error message when server returns HTML
+		if strings.Contains(err.Error(), "invalid character '<'") {
+			return nil, fmt.Errorf("Dependency-Track API returned HTML instead of JSON. Please ensure the URL is correct (e.g., http://localhost:8080) and the API server is running. Original error: %w", err)
+		}
+
+		return nil, fmt.Errorf("failed to create Dependency-Track client: %w", err)
 	}
 
-	return &DependencyTrackClient{Client: client}
+	return &DependencyTrackClient{Client: client}, nil
 }
 
 type Project struct {

--- a/pkg/target/dependencytrack/config.go
+++ b/pkg/target/dependencytrack/config.go
@@ -14,6 +14,11 @@
 
 package dependencytrack
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 type DependencyTrackConfig struct {
 	APIURL         string
 	APIKey         string
@@ -28,4 +33,35 @@ func NewDependencyTrackConfig(apiURL, version string, overwite bool) *Dependency
 		ProjectVersion: version,
 		Overwrite:      overwite,
 	}
+}
+
+// String returns a sanitized string representation of the config (for logging)
+// The API key is masked for security
+func (c *DependencyTrackConfig) String() string {
+	apiKeyMasked := maskAPIKey(c.APIKey)
+	return fmt.Sprintf("{APIURL:%s APIKey:%s ProjectName:%s ProjectVersion:%s Overwrite:%t}",
+		c.APIURL, apiKeyMasked, c.ProjectName, c.ProjectVersion, c.Overwrite)
+}
+
+// MarshalJSON returns a JSON representation with masked API key
+func (c *DependencyTrackConfig) MarshalJSON() ([]byte, error) {
+	type alias DependencyTrackConfig // create alias to avoid infinite recursion
+	return json.Marshal(&struct {
+		*alias
+		APIKey string `json:"APIKey"`
+	}{
+		alias:  (*alias)(c),
+		APIKey: maskAPIKey(c.APIKey),
+	})
+}
+
+// maskAPIKey masks the API key for logging, showing only first 8 and last 4 characters
+func maskAPIKey(apiKey string) string {
+	if apiKey == "" {
+		return ""
+	}
+	if len(apiKey) > 12 {
+		return apiKey[:8] + "***" + apiKey[len(apiKey)-4:]
+	}
+	return "***"
 }

--- a/pkg/target/dependencytrack/validation.go
+++ b/pkg/target/dependencytrack/validation.go
@@ -22,10 +22,10 @@ import (
 	"net/url"
 )
 
-func ValidateDTrackConnection(url, token string) error {
+func ValidateDTrackConnection(apiURL, token string) error {
 	ctx := context.Background()
 
-	baseURL, err := genHealthzUrl(url)
+	baseURL, err := genHealthzUrl(apiURL)
 	if err != nil {
 		return fmt.Errorf("invalid URL format: %w", err)
 	}


### PR DESCRIPTION
closes #207 
This PR adds the following changes:
- The nil client fix with proper error handling
  - The API's of dtrack are exposed to a port 8080 by default, whereas in our case it was 8081, one can override from its docker file. As a result the creation of client fails, as it was making request to `http://localhost:8081` and returns nil client. And the nil client does log about it, but doesn't return an error. As a result on any fucntion or method invoke to the client, throws a pointer error.
- Earlier in the log, API key was exposed
  - Now it has been masked.
- Updated the docs for port 8080
- Bump the dtrack from `v0.18.0` to `v0.19.0`

COmmand o/p:
<details>
<summary>sbommv transfer SBOM from folder to dtrack log output</summary>

```bash
 go run main.go transfer \
--input-adapter=folder \
--in-folder-path=testdata/github/sbomqs_github_api_sbom.spdx.json \
--output-adapter=dtrack \
--out-dtrack-url="http://localhost:8080" --debug
2026-07-08T20:22:27.017+0530	DEBUG	logger/log.go:97	Starting transferSBOM
2026-07-08T20:22:27.017+0530	DEBUG	logger/log.go:97	configuration	{"value": {"SourceAdapter":"folder","DestinationAdapter":"dtrack","ProcessingStrategy":"sequential","DryRun":false,"Daemon":false,"Overwrite":false}}
2026-07-08T20:22:27.017+0530	DEBUG	logger/log.go:97	Starting SBOM transfer process....
2026-07-08T20:22:27.017+0530	DEBUG	logger/log.go:97	Initializing Input Adapter	{"InputAdapter": "folder"}
2026-07-08T20:22:27.017+0530	DEBUG	logger/log.go:97	Initializing Output Adapter	{"OutputAdapter": "dtrack"}
2026-07-08T20:22:27.017+0530	DEBUG	logger/log.go:97	Input adapter instance config	{"value": {"Config":{"FolderPath":"testdata/github/sbomqs_github_api_sbom.spdx.json","Recursive":false,"ProcessingMode":"sequential","Daemon":false},"Role":"input","Fetcher":{}}}
2026-07-08T20:22:27.030+0530	DEBUG	logger/log.go:97	Output adapter instance config	{"value": {"Config":{"APIURL":"http://localhost:8080","ProjectName":"","ProjectVersion":"","Overwrite":false,"APIKey":"odt_rpzj***8mer"},"Uploader":{},"Role":"output","ProcessingMode":"sequential","Overwrite":false}}
2026-07-08T20:22:27.030+0530	DEBUG	logger/log.go:97	Initializing SBOM fetching	{"mode": "sequential"}
2026-07-08T20:22:27.030+0530	DEBUG	logger/log.go:97	Fetching SBOMs Sequentially
2026-07-08T20:22:27.031+0530	DEBUG	logger/log.go:97	Locally SBOM located folder	{"path": "testdata/github/sbomqs_github_api_sbom.spdx.json"}
2026-07-08T20:22:27.031+0530	DEBUG	logger/log.go:97	Checking adapter eligibility for undergoing conversion layer	{"adapter type": "dtrack"}
2026-07-08T20:22:27.032+0530	DEBUG	logger/log.go:97	Adapter is eligible for SBOM conversion	{"adapter type": "dtrack"}
2026-07-08T20:22:27.032+0530	DEBUG	logger/log.go:97	Initializing SBOMs uploading to Dependency-Track sequentially

2026-07-08T20:22:27.032+0530	DEBUG	logger/log.go:97	Iniatializing for SBOM conversion from SPDX to CDX
2026-07-08T20:22:27.033+0530	DEBUG	logger/log.go:97	Detected SPDX SBOM	{"version": "SPDX-2.3"}
2026-07-08T20:22:27.047+0530	DEBUG	logger/log.go:97	Converting SBOM	{"source": "spdx", "source version": "SPDX-2.3", "target": "cyclonedx"}
2026-07-08T20:22:27.047+0530	DEBUG	logger/log.go:97	Initializing protobom serialization of SBOM from SPDX to CycloneDX
2026-07-08T20:22:27.047+0530	DEBUG	logger/log.go:97	Starting WriteStreamWithOptions	{"nodeCount": 61}
2026-07-08T20:22:27.062+0530	DEBUG	logger/log.go:97	Finished WriteStreamWithOptions
2026-07-08T20:22:27.063+0530	DEBUG	logger/log.go:97	Successfully protobom serialization of SBOM from SPDX to CycloneDX
2026-07-08T20:22:27.063+0530	DEBUG	logger/log.go:97	Constructing Project Name and Version	{"providedProjectName": "", "providedProjectVersion": "", "ownerRepoName": "testdata/github/sbomqs_github_api_sbom.spdx.json", "repoVersion": "", "source": "folder", "assetpath": "."}
2026-07-08T20:22:27.064+0530	DEBUG	logger/log.go:97	SBOM File Format is in JSON format
2026-07-08T20:22:27.064+0530	DEBUG	logger/log.go:97	Project Name and Version	{"name": "com.github.interlynk-io/sbomqs", "version": "main"}
2026-07-08T20:22:27.064+0530	DEBUG	logger/log.go:97	Project Details	{"project_name": "com.github.interlynk-io/sbomqs-main"}
2026-07-08T20:22:27.064+0530	DEBUG	logger/log.go:97	Processing finding or Creating Project	{"project": "com.github.interlynk-io/sbomqs-main", "version": "latest"}
2026-07-08T20:22:27.064+0530	DEBUG	logger/log.go:97	Finding Project	{"project": "com.github.interlynk-io/sbomqs-main", "version": "latest"}
2026-07-08T20:22:27.127+0530	DEBUG	logger/log.go:97	Total Number of Projects Available in Dependency Track Platform	{"count": 2}
2026-07-08T20:22:27.127+0530	DEBUG	logger/log.go:97	Project found	{"project": "com.github.interlynk-io/sbomqs-main", "version": "latest", "id": "b802887e-ec1f-419b-b145-ae7854fd4d01"}
2026-07-08T20:22:27.127+0530	DEBUG	logger/log.go:97	Project already exists, therefor it wouldn't create a new	{"project": "com.github.interlynk-io/sbomqs-main", "uuid": "b802887e-ec1f-419b-b145-ae7854fd4d01"}
2026-07-08T20:22:27.128+0530	DEBUG	logger/log.go:97	Initializing uploading SBOM content	{"size": 24654, "file": "."}
2026-07-08T20:22:27.176+0530	DEBUG	logger/log.go:97	Exists	{"project": "com.github.interlynk-io/sbomqs-main", "uuid": "b802887e-ec1f-419b-b145-ae7854fd4d01"}
2026-07-08T20:22:27.176+0530	DEBUG	logger/log.go:97	Metrics	{"components": {"firstOccurrence":1783518871208,"lastOccurrence":1783518871208,"inheritedRiskScore":0,"vulnerabilities":0,"vulnerableComponents":0,"components":60,"suppressed":0,"critical":0,"high":0,"medium":0,"low":0,"unassigned":0,"findingsTotal":0,"findingsAudited":0,"findingsUnaudited":0,"policyViolationsTotal":0,"policyViolationsFail":0,"policyViolationsWarn":0,"policyViolationsInfo":0,"policyViolationsAudited":0,"policyViolationsUnaudited":0,"policyViolationsSecurityTotal":0,"policyViolationsSecurityAudited":0,"policyViolationsSecurityUnaudited":0,"policyViolationsLicenseTotal":0,"policyViolationsLicenseAudited":0,"policyViolationsLicenseUnaudited":0,"policyViolationsOperationalTotal":0,"policyViolationsOperationalAudited":0,"policyViolationsOperationalUnaudited":0}, "last_bom_import": 1783518868550}
2026-07-08T20:22:27.176+0530	DEBUG	logger/log.go:97	Active Status	{"active": true}
2026-07-08T20:22:27.176+0530	DEBUG	logger/log.go:97	Has SBOM	{"has_sbom": true}
2026-07-08T20:22:27.176+0530	INFO	logger/log.go:102	exists	{"skip upload": true, "project": "com.github.interlynk-io/sbomqs-main", "uuid": "b802887e-ec1f-419b-b145-ae7854fd4d01"}
2026-07-08T20:22:27.176+0530	INFO	logger/log.go:102	upload	{"sboms": 1, "success": 1, "failed": 0}
2026-07-08T20:22:27.176+0530	DEBUG	logger/log.go:97	SBOM transfer process completed successfully ✅

```
</details>